### PR TITLE
Tweak to Audio Lock Fix (Fixes Vita Crashing as well)

### DIFF
--- a/Sonic12Decomp/Audio.cpp
+++ b/Sonic12Decomp/Audio.cpp
@@ -27,8 +27,8 @@ MusicPlaybackInfo musInfo;
 SDL_AudioDeviceID audioDevice;
 SDL_AudioSpec audioDeviceFormat;
 
-#define LOCK_AUDIO_DEVICE() SDL_LockAudioDevice(audioDevice);
-#define UNLOCK_AUDIO_DEVICE() SDL_UnlockAudioDevice(audioDevice);
+#define LOCK_AUDIO_DEVICE() SDL_LockAudio();
+#define UNLOCK_AUDIO_DEVICE() SDL_UnlockAudio();
 
 #define AUDIO_FREQUENCY (44100)
 #define AUDIO_FORMAT    (AUDIO_S16SYS) /**< Signed 16-bit samples */


### PR DESCRIPTION
While the previous fix works perfectly on platforms with an officially supported SDL2 library using the recommended methods, some platforms (including the Vita) will need to still use the Legacy SDL_Lock/UnlockAudio functions to alleviate the crashes. SDL_Lock/UnlockAudio is already used in Audio.hpp as well, so this makes sure everything is consistent.

This should not change anything functionally for all other platforms that support SDL2.