### PR TITLE
more switch enhancements

### DIFF
--- a/Sonic1.NX/Makefile
+++ b/Sonic1.NX/Makefile
@@ -9,7 +9,8 @@ include $(DEVKITPRO)/libnx/switch_rules
 
 TARGET		:=	sonic1
 BUILD		:=	build
-SOURCES		:=	../Sonic12Decomp/ \    
+SOURCES		:=	../Sonic12Decomp/ \
+				../Sonic12Decomp/platform/
 
 DATA		:=	data
 INCLUDES	:=	../Sonic12Decomp
@@ -25,6 +26,10 @@ CFLAGS	:=	-O2 -ffunction-sections \
 			$(ARCH) $(DEFINES)
 
 CFLAGS	+=	$(INCLUDE) -D__SWITCH__ -I/opt/devkitpro/portlibs/switch/include/SDL2/
+
+ifneq ($(strip $(APPLICATION_ID)),)
+	CFLAGS	+= -DNX_APPLICATION_ID=0
+endif
 
 CXXFLAGS	:= $(CFLAGS) -std=gnu++17 -Wno-missing-field-initializers -Wno-missing-braces -Wno-unused-variable -Wno-unused-parameter -fpermissive -Wno-address-of-packed-member
 
@@ -68,8 +73,6 @@ export LIBPATHS	:=	$(foreach dir,$(LIBDIRS),-L$(dir)/lib)
 
 export BUILD_EXEFS_SRC := $(TOPDIR)/$(EXEFS_SRC)
 
-$(info $$OFILES is [${SOURCES}])
-
 ifeq ($(strip $(ICON)),)
 	icons := $(wildcard *.jpg)
 	ifneq (,$(findstring $(TARGET).jpg,$(icons)))
@@ -98,8 +101,6 @@ endif
 ifneq ($(ROMFS),)
 	export NROFLAGS += --romfsdir=$(CURDIR)/$(ROMFS)
 endif
-
-
 
 
 .PHONY: $(BUILD) clean all

--- a/Sonic12Decomp/Debug.hpp
+++ b/Sonic12Decomp/Debug.hpp
@@ -4,6 +4,7 @@
 extern bool endLine;
 inline void printLog(const char *msg, ...)
 {
+#ifndef RETRO_DISABLE_LOG
     if (engineDebugMode) {
         char buffer[0x100];
 
@@ -33,12 +34,15 @@ inline void printLog(const char *msg, ...)
         if (file) {
             fWrite(&buffer, 1, StrLength(buffer), file);
             fClose(file);
+            RETRO_FILE_COMMIT_FUNC();
         }
     }
+#endif
 }
 
 inline void printLog(const ushort *msg)
 {
+#ifndef RETRO_DISABLE_LOG
     if (engineDebugMode) {
         int mPos = 0;
         while (msg[mPos]) {
@@ -69,8 +73,10 @@ inline void printLog(const ushort *msg)
             if (endLine)
                 fWrite(&el, 2, 1, file);
             fClose(file);
+            RETRO_FILE_COMMIT_FUNC();
         }
     }
+#endif
 }
 
 enum DevMenuMenus {

--- a/Sonic12Decomp/Ini.cpp
+++ b/Sonic12Decomp/Ini.cpp
@@ -235,6 +235,7 @@ int IniParser::SetComment(const char *section, const char *key, const char *comm
 
 void IniParser::Write(const char *filename)
 {
+#ifndef RETRO_DISABLE_SETTINGS_SAVE
     char pathBuffer[0x80];
 
 #if RETRO_PLATFORM == RETRO_OSX
@@ -299,4 +300,6 @@ void IniParser::Write(const char *filename)
     }
 
     fClose(f);
+    RETRO_FILE_COMMIT_FUNC();
+#endif
 }

--- a/Sonic12Decomp/RetroEngine.hpp
+++ b/Sonic12Decomp/RetroEngine.hpp
@@ -76,17 +76,23 @@ typedef unsigned int uint;
 #define DEFAULT_FULLSCREEN   false
 #define SCREEN_YSIZE (272)
 #elif RETRO_PLATFORM == RETRO_NX
+#include "platform/nx.h"
 
+#ifdef NX_APPLICATION_ID
+#define BASE_PATH "save:/"
+#else
 #define BASE_PATH ""
+#endif
 #define BASE_RO_PATH "romfs:/"
 #define DEFAULT_SCREEN_XSIZE 480
 #define DEFAULT_FULLSCREEN   false
 #define SCREEN_YSIZE         (272)
 #define DEFAULT_WINDOW_SCALE 4
 #define RETRO_DISABLE_CONTROLLER_HOTSWAP
-
+#define RETRO_DISABLE_SETTINGS_SAVE
+#define RETRO_DISABLE_LOG
+#define RETRO_FILE_COMMIT_FUNC commitSave
 #else
-
 #define BASE_PATH            ""
 #define BASE_RO_PATH         ""
 #define DEFAULT_SCREEN_XSIZE 424 
@@ -100,6 +106,10 @@ typedef unsigned int uint;
 
 #ifndef DEFAULT_WINDOW_SCALE
 #define DEFAULT_WINDOW_SCALE 2
+#endif
+
+#ifndef RETRO_FILE_COMMIT_FUNC
+#define RETRO_FILE_COMMIT_FUNC(x)
 #endif
 
 #if RETRO_PLATFORM == RETRO_WINDOWS || RETRO_PLATFORM == RETRO_OSX || RETRO_PLATFORM == RETRO_VITA || RETRO_PLATFORM == RETRO_NX

--- a/Sonic12Decomp/Userdata.cpp
+++ b/Sonic12Decomp/Userdata.cpp
@@ -324,6 +324,8 @@ void WriteUserdata()
     if (Engine.onlineActive) {
         // Load from online
     }
+
+    RETRO_FILE_COMMIT_FUNC();
 }
 
 void AwardAchievement(int id, int status)

--- a/Sonic12Decomp/Userdata.hpp
+++ b/Sonic12Decomp/Userdata.hpp
@@ -118,6 +118,7 @@ inline bool WriteSaveRAMData()
         return false;
     fWrite(saveRAM, 4u, SAVEDATA_MAX, saveFile);
     fClose(saveFile);
+    RETRO_FILE_COMMIT_FUNC();
     return true;
 }
 

--- a/Sonic12Decomp/main.cpp
+++ b/Sonic12Decomp/main.cpp
@@ -1,26 +1,5 @@
 #include "RetroEngine.hpp"
 
-#if RETRO_PLATFORM == RETRO_NX
-#include <switch.h>
-
-extern "C" {
-    void userAppInit(void);
-    void userAppExit(void);
-}
-
-void userAppInit(void)
-{
-    hidInitialize();
-    romfsInit();
-}
-
-void userAppExit(void)
-{
-    romfsExit();
-    hidExit();
-}
-#endif
-
 int main(int argc, char *argv[])
 {
     for (int i = 0; i < argc; ++i) {
@@ -29,6 +8,16 @@ int main(int argc, char *argv[])
     }
 
     Engine.Init();
+
+#ifdef __SWITCH__
+    // swap A, B to correct positions
+    SDL_GameControllerAddMapping("53776974636820436F6E74726F6C6C65,Switch Controller,"
+                                 "a:b0,b:b1,back:b11,"
+                                 "dpdown:b15,dpleft:b12,dpright:b14,dpup:b13,"
+                                 "leftshoulder:b6,leftstick:b4,lefttrigger:b8,leftx:a0,lefty:a1,"
+                                 "rightshoulder:b7,rightstick:b5,righttrigger:b9,rightx:a2,righty:a3,"
+                                 "start:b10,x:b3,y:b2");
+#endif
 
 #ifdef RETRO_DISABLE_CONTROLLER_HOTSWAP
     controllerInit(0);

--- a/Sonic12Decomp/platform/NX.cpp
+++ b/Sonic12Decomp/platform/NX.cpp
@@ -1,0 +1,83 @@
+#ifdef __SWITCH__
+#include <switch.h>
+#include "nx.h"
+
+extern "C" {
+    void userAppInit(void);
+    void userAppExit(void);
+}
+
+void userAppInit()
+{
+    smInitialize();
+    fsInitialize();
+    hidInitialize();
+    romfsInit();
+
+#ifdef NX_APPLICATION_ID
+    accountInitialize(AccountServiceType_Application);
+    mountSaveData();
+#endif
+}
+
+void userAppExit() 
+{
+#ifdef NX_APPLICATION_ID
+    unmountSaveData();
+#endif
+
+    romfsExit();
+    hidExit();
+}
+
+AccountUid currentUser()
+{
+    AccountUid uid;
+
+    uid.uid[0] = 0;
+    uid.uid[1] = 0;
+
+    if (accountGetPreselectedUser(&uid)) {
+    }
+
+    return uid;
+}
+
+int mountSaveData()
+{
+#ifdef NX_APPLICATION_ID
+    FsFileSystem fileSystem;
+
+    if (fsOpen_SaveData(&fileSystem, NX_APPLICATION_ID, currentUser())) {
+        return -1;
+    }
+
+    if (fsdevMountDevice("save", fileSystem) == -1) {
+        fsdevUnmountDevice("save");
+        return -2;
+    }
+#endif
+    return 0;
+}
+
+int unmountSaveData()
+{
+#ifdef NX_APPLICATION_ID
+    if (fsdevUnmountDevice("save") == -1) {
+        return -1;
+    }
+#endif
+    return 0;
+}
+
+int commitSave()
+{
+#ifdef NX_APPLICATION_ID
+    return fsdevCommitDevice("save");
+#else
+    return 0;
+#endif
+}
+
+
+#endif

--- a/Sonic12Decomp/platform/nx.h
+++ b/Sonic12Decomp/platform/nx.h
@@ -1,0 +1,8 @@
+#pragma once
+#ifdef __SWITCH__
+int mountSaveData();
+int unmountSaveData();
+int commitSave();
+#endif
+
+

--- a/Sonic2.NX/Makefile
+++ b/Sonic2.NX/Makefile
@@ -9,7 +9,8 @@ include $(DEVKITPRO)/libnx/switch_rules
 
 TARGET		:=	sonic2
 BUILD		:=	build
-SOURCES		:=	../Sonic12Decomp/ \    
+SOURCES		:=	../Sonic12Decomp/ \
+				../Sonic12Decomp/platform/
 
 DATA		:=	data
 INCLUDES	:=	../Sonic12Decomp
@@ -25,6 +26,10 @@ CFLAGS	:=	-O2 -ffunction-sections \
 			$(ARCH) $(DEFINES)
 
 CFLAGS	+=	$(INCLUDE) -D__SWITCH__ -I/opt/devkitpro/portlibs/switch/include/SDL2/
+
+ifneq ($(strip $(APPLICATION_ID)),)
+	CFLAGS	+= -DNX_APPLICATION_ID=0
+endif
 
 CXXFLAGS	:= $(CFLAGS) -std=gnu++17 -Wno-missing-field-initializers -Wno-missing-braces -Wno-unused-variable -Wno-unused-parameter -fpermissive -Wno-address-of-packed-member
 
@@ -68,8 +73,6 @@ export LIBPATHS	:=	$(foreach dir,$(LIBDIRS),-L$(dir)/lib)
 
 export BUILD_EXEFS_SRC := $(TOPDIR)/$(EXEFS_SRC)
 
-$(info $$OFILES is [${SOURCES}])
-
 ifeq ($(strip $(ICON)),)
 	icons := $(wildcard *.jpg)
 	ifneq (,$(findstring $(TARGET).jpg,$(icons)))
@@ -98,8 +101,6 @@ endif
 ifneq ($(ROMFS),)
 	export NROFLAGS += --romfsdir=$(CURDIR)/$(ROMFS)
 endif
-
-
 
 
 .PHONY: $(BUILD) clean all


### PR DESCRIPTION
There are multiple different filesystems on the switch.   By default this project was reading/writing to the SD card which is unreliable for two reasons:

1) the SD card is common to all users, so you cannot take advantage of user specific saves.
2) The SD card is extremely prone to corruption when you write to it.  Therefore there is a high risk of data loss / losing your saves.

The switch has a durable journaled file system intended specifically for save data and is per user, this PR adds support for that.  run "make APPLICATION_ID=0" to build for this, however this should only be used with the NSO to make a NSP file, and not be used with the NRO.

I have code I could commit for building the entire NSP file, however it is windows specific so I left it out unless you want me to bring it in.

Logging was completely disabled for NX due to the before mentioned file system corruption problems on the SD card on the switch.  You should never write to the SD card unless absolutely necessary.