### PR TITLE
Makefile: Allow BASE_PATH configuration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,6 @@
-CXXFLAGS_ALL = $(shell pkg-config --cflags sdl2 vorbisfile vorbis) $(CXXFLAGS)
+CXXFLAGS_ALL = $(shell pkg-config --cflags sdl2 vorbisfile vorbis) $(CXXFLAGS) \
+               -DBASE_PATH='"$(BASE_PATH)"'
+
 LDFLAGS_ALL = $(LDFLAGS)
 LIBS_ALL = $(shell pkg-config --libs sdl2 vorbisfile vorbis) -pthread $(LIBS)
 

--- a/Sonic12Decomp/RetroEngine.hpp
+++ b/Sonic12Decomp/RetroEngine.hpp
@@ -70,12 +70,15 @@ typedef unsigned int uint;
 #define DEFAULT_FULLSCREEN   false
 #define SCREEN_YSIZE         (272)
 #else
-#define BASE_PATH            ""
 #define DEFAULT_SCREEN_XSIZE 424
 #define DEFAULT_FULLSCREEN   false
 #define SCREEN_YSIZE         (240)
 #define RETRO_USING_MOUSE
 #define RETRO_USING_TOUCH
+#endif
+
+#ifndef BASE_PATH
+#define BASE_PATH            ""
 #endif
 
 #if RETRO_PLATFORM == RETRO_WINDOWS || RETRO_PLATFORM == RETRO_OSX || RETRO_PLATFORM == RETRO_VITA


### PR DESCRIPTION
This allows tweaking the BASE_PATH by passing it as an arg to Make.