### PR TITLE
Fix typos causing S1 Spikes Game Option to function incorrectly

### DIFF
--- a/Sonic12Decomp/Debug.cpp
+++ b/Sonic12Decomp/Debug.cpp
@@ -693,7 +693,7 @@ void setTextMenu(int sm) {
                 else
                     AddTextMenuEntry(&gameMenu[1], "AIR SPEED CAP: DISABLED");
                 AddTextMenuEntry(&gameMenu[1], "");
-                if (GetGlobalVariableByName("options.spikeBehaviour"))
+                if (GetGlobalVariableByName("options.spikeBehavior"))
                     AddTextMenuEntry(&gameMenu[1], "S1 SPIKES: ENABLED");
                 else
                     AddTextMenuEntry(&gameMenu[1], "S1 SPIKES: DISABLED");
@@ -724,7 +724,7 @@ void setTextMenu(int sm) {
                 else
                     AddTextMenuEntry(&gameMenu[1], "SUPER TAILS: DISABLED");
                 AddTextMenuEntry(&gameMenu[1], "");
-                if (GetGlobalVariableByName("options.spikeBehaviour"))
+                if (GetGlobalVariableByName("options.spikeBehavior"))
                     AddTextMenuEntry(&gameMenu[1], "S1 SPIKES: ENABLED");
                 else
                     AddTextMenuEntry(&gameMenu[1], "S1 SPIKES: DISABLED");


### PR DESCRIPTION
Option would show "Disabled" regardless of actual internal value upon entering the menu.