### PR TITLE
String optimizations + bugfix

### DIFF
--- a/Sonic12Decomp/Script.cpp
+++ b/Sonic12Decomp/Script.cpp
@@ -2419,7 +2419,7 @@ void ProcessScript(int scriptCodePtr, int jumpTablePtr, byte scriptEvent)
         int opcodeSize       = functions[opcode].opcodeSize;
         int scriptCodeOffset = scriptDataPtr;
 
-        StrCopy(scriptText, "");
+        scriptText[0] = '\0';
 
         // Get Values
         for (int i = 0; i < opcodeSize; ++i) {

--- a/Sonic12Decomp/String.hpp
+++ b/Sonic12Decomp/String.hpp
@@ -6,6 +6,8 @@
 
 #define CREDITS_LIST_SIZE (0x200)
 
+#define USE_STDLIB
+
 extern ushort *strPressStart;
 extern ushort *strTouchToStart;
 extern ushort *strStartGame;
@@ -79,11 +81,17 @@ extern float creditsAdvanceY[CREDITS_LIST_SIZE];
 
 inline void StrCopy(char *dest, const char *src)
 {
+    #ifdef USE_STDLIB
+    strcpy(dest, src);
+
+    #else
     int i = 0;
 
     for (; src[i]; ++i) dest[i] = src[i];
 
     dest[i] = 0;
+
+    #endif
 }
 
 inline void StrAdd(char *dest, const char *src)
@@ -124,10 +132,16 @@ inline bool StrComp(const char *stringA, const char *stringB)
 
 inline int StrLength(const char *string)
 {
+    #ifdef USE_STDLIB
+    return strlen(string);
+
+    #else
     int len = 0;
     for (len = 0; string[len]; len++)
         ;
     return len;
+
+    #endif
 }
 int FindStringToken(const char *string, const char *token, char stopID);
 

--- a/Sonic12Decomp/Text.cpp
+++ b/Sonic12Decomp/Text.cpp
@@ -43,7 +43,8 @@ void AddTextMenuEntry(TextMenu *menu, const char *text)
 {
     menu->entryStart[menu->rowCount] = menu->textDataPos;
     menu->entrySize[menu->rowCount]  = 0;
-    for (int i = 0; i < StrLength(text);) {
+    int textLength                   = StrLength(text);
+    for (int i = 0; i < textLength;) {
         if (text[i] != '\0') {
             menu->textData[menu->textDataPos++] = text[i];
             menu->entrySize[menu->rowCount]++;
@@ -59,7 +60,8 @@ void AddTextMenuEntryW(TextMenu *menu, const ushort *text)
 {
     menu->entryStart[menu->rowCount] = menu->textDataPos;
     menu->entrySize[menu->rowCount]  = 0;
-    for (int i = 0; i < StrLengthW(text);) {
+    int textLength                   = StrLengthW(text);
+    for (int i = 0; i < textLength;) {
         if (text[i] != '\0') {
             menu->textData[menu->textDataPos++] = text[i];
             menu->entrySize[menu->rowCount]++;
@@ -75,7 +77,8 @@ void SetTextMenuEntry(TextMenu *menu, const char *text, int rowID)
 {
     menu->entryStart[rowID] = menu->textDataPos;
     menu->entrySize[rowID]  = 0;
-    for (int i = 0; i < StrLength(text);) {
+    int textLength          = StrLength(text);
+    for (int i = 0; i < textLength;) {
         if (text[i] != '\0') {
             menu->textData[menu->textDataPos++] = text[i];
             menu->entrySize[rowID]++;
@@ -90,7 +93,8 @@ void SetTextMenuEntryW(TextMenu *menu, const ushort *text, int rowID)
 {
     menu->entryStart[rowID] = menu->textDataPos;
     menu->entrySize[rowID]  = 0;
-    for (int i = 0; i < StrLengthW(text);) {
+    int textLength          = StrLengthW(text);
+    for (int i = 0; i < textLength;) {
         if (text[i] != '\0') {
             menu->textData[menu->textDataPos++] = text[i];
             menu->entrySize[rowID]++;
@@ -105,7 +109,8 @@ void EditTextMenuEntry(TextMenu *menu, const char *text, int rowID)
 {
     int entryPos             = menu->entryStart[rowID];
     menu->entrySize[rowID] = 0;
-    for (int i = 0; i < StrLength(text);) {
+    int textLength         = StrLength(text);
+    for (int i = 0; i < textLength;) {
         if (text[i] != '\0') {
             menu->textData[entryPos++] = text[i];
             menu->entrySize[rowID]++;

--- a/Sonic12Decomp/Userdata.cpp
+++ b/Sonic12Decomp/Userdata.cpp
@@ -274,7 +274,7 @@ void writeSettings()
     ini.SetInteger("Controller 1", "C", inputDevice[6].contMappings);
     ini.SetInteger("Controller 1", "Start", inputDevice[7].contMappings);
 
-    ini.Write("settings.ini");
+    ini.Write(BASE_PATH"settings.ini");
 }
 
 void ReadUserdata()


### PR DESCRIPTION
The function `writeSettings` was writing to the wrong location.

Also by running a profiler I noticed that one of the major slowdowns depended on how the strings were processed. In `Script.cpp` the change to `scriptText[0] = '\0';` effectively gives a decent boost as is frequently called and virtually equal to `StrCopy(scriptText, "")`. Also StrCopy and StrLength are not _optionally_ replaced with the stdlib functions, which are generally faster.
