### PR TITLE
Fix DELETE SAVE FILE weirdness

### DIFF
--- a/Sonic12Decomp/Debug.cpp
+++ b/Sonic12Decomp/Debug.cpp
@@ -865,11 +865,11 @@ void processStartMenu() {
                 }
                 else if (gameMenu[1].selection1 == 2) {
                     if (!gameMenu[1].selection2) {
-                        SetTextMenuEntry(&gameMenu[1], "CANCEL", 0);
+                        SetTextMenuEntry(&gameMenu[1], "CANCEL", 2);
                         gameMenu[1].selection2 ^= 1;
                     }
                     else {
-                        SetTextMenuEntry(&gameMenu[1], "DELETE SAVE FILE", 0);
+                        SetTextMenuEntry(&gameMenu[1], "DELETE SAVE FILE", 2);
                         gameMenu[1].selection2 ^= 1;
                     }
                 }


### PR DESCRIPTION
After activating the "DELETE SAVE FILE" option on the "SELECT A SAVE FILE" screen, "GAME OPTIONS" would be replaced with "CANCEL". This would cause you to enter the game options when attempting to cancel a delete operation. The surrounding code implies it should really be replacing "DELETE SAVE FILE" as there is code to revert the text to its original state.