### PR TITLE
Initialize Window to Scaled Value

### DIFF
--- a/Sonic12Decomp/Drawing.cpp
+++ b/Sonic12Decomp/Drawing.cpp
@@ -30,7 +30,8 @@ int InitRenderDevice()
     SDL_SetHint(SDL_HINT_RENDER_SCALE_QUALITY, "nearest");
     SDL_SetHint(SDL_HINT_RENDER_VSYNC, Engine.vsync ? "1" : "0");
 
-    Engine.window = SDL_CreateWindow(gameTitle, SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED, SCREEN_XSIZE, SCREEN_YSIZE,
+    Engine.window = SDL_CreateWindow(gameTitle, SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED,
+    SCREEN_XSIZE * Engine.windowScale, SCREEN_YSIZE * Engine.windowScale,
                                      SDL_WINDOW_RESIZABLE | SDL_WINDOW_ALLOW_HIGHDPI);
 
     Engine.renderer = SDL_CreateRenderer(Engine.window, -1, SDL_RENDERER_ACCELERATED);
@@ -68,9 +69,6 @@ int InitRenderDevice()
         SDL_SetWindowFullscreen(Engine.window, SDL_WINDOW_FULLSCREEN_DESKTOP);
         SDL_ShowCursor(SDL_FALSE);
         Engine.isFullScreen = true;
-    }
-    else {
-        SDL_SetWindowSize(Engine.window, SCREEN_XSIZE * Engine.windowScale, SCREEN_YSIZE * Engine.windowScale);
     }
 
     if (Engine.borderless) {


### PR DESCRIPTION
Perviously the window was initialized to the base width+height, and then manually resized later; now it simply gets initialized to the scaled value.