### PR TITLE
Removed MSYS2 Intruction, Can't use exe without MSYS2 installed. Tweaked Arch Linux instructions.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-CXXFLAGS_ALL = $(shell pkg-config --cflags -mwindows sdl2 vorbisfile vorbis -static) $(CXXFLAGS) \
+CXXFLAGS_ALL = $(shell pkg-config --cflags -mwindows sdl2 vorbisfile vorbis) $(CXXFLAGS) \
                -DBASE_PATH='"$(BASE_PATH)"'
 
 LDFLAGS_ALL = $(LDFLAGS)

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-CXXFLAGS_ALL = $(shell pkg-config --cflags sdl2 vorbisfile vorbis) $(CXXFLAGS) \
+CXXFLAGS_ALL = $(shell pkg-config --cflags -mwindows sdl2 vorbisfile vorbis -static) $(CXXFLAGS) \
                -DBASE_PATH='"$(BASE_PATH)"'
 
 LDFLAGS_ALL = $(LDFLAGS)

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-CXXFLAGS_ALL = $(shell pkg-config --cflags -mwindows sdl2 vorbisfile vorbis) $(CXXFLAGS) \
+CXXFLAGS_ALL = $(shell pkg-config --cflags sdl2 vorbisfile vorbis) $(CXXFLAGS) \
                -DBASE_PATH='"$(BASE_PATH)"'
 
 LDFLAGS_ALL = $(LDFLAGS)

--- a/README.md
+++ b/README.md
@@ -35,14 +35,6 @@ If you want to transfer your save from the **Android pre-forever versions,** you
 * Clone the repo, then follow the instructions in the [depencencies readme for windows](./dependencies/windows/dependencies.txt) to setup dependencies, then build via the visual studio solution
 * or grab a prebuilt executable from the releases section
 
-## Windows via MSYS2:
-* Download the newest version of the MSYS2 installer from [here](https://github.com/msys2/msys2-installer/releases) and install it.
-* Run the `MINGW64` prompt (from the windows Start Menu/MSYS2 64-bit/MSYS2 MinGW 64-bit), when the program starts enter `pacman -Syuu` in the prompt and hit Enter. Press `Y` when it asks if you want to update packages. If it asks you to close the prompt, do so, then restart it and run the same command again. This updates the packages to their latest versions.
-* Now install the dependencies with the following command: `pacman -S make git mingw-w64-i686-gcc mingw-w64-x86_64-gcc mingw-w64-x86_64-SDL2 mingw-w64-x86_64-libogg mingw-w64-x86_64-libvorbis`
-* Clone the repo with the following command: `git clone https://github.com/Rubberduckycooly/Sonic-1-2-2013-Decompilation.git`
-* Go into the repo you just cloned with `cd Sonic-1-2-2013-Decompilation`
-* Then run `make -j4` (-j switch is optional but will make building faster, it's based on the number of cores you have +1 so 8 cores wold be -j9)
-
 ## Windows UWP (Phone, Xbox, etc.):
 * Clone the repo, then follow the instructions in the [depencencies readme for Windows](./dependencies/windows/dependencies.txt) and [depencencies readme for UWP](./dependencies/windows-uwp/dependencies.txt) to setup dependencies, copy your `Data.rsdk` folder into `Sonic1Decomp.UWP` or `Sonic2Decomp.UWP` depending on the game, then build and deploy via `Sonic12Decomp.UWP.sln`
 * You may also need to generate visual assets, to do so, open the Package.appxmanifest file in the designer, under the Visual Assets tab, select an image of your choice and click generate.

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ If you want to transfer your save from the **Android pre-forever versions,** you
 ## Linux:
 * To setup your build enviroment and library dependecies run the following commands:
 * Ubuntu (Mint, Pop!_OS, etc...): `sudo apt install build-essential git libsdl2-dev libvorbis-dev libogg-dev`
-* Arch Linux: `sudo pacman -Sy base-devel git sdl2 libvorbis libogg`
+* Arch Linux: `sudo pacman -S base-devel git sdl2 libvorbis libogg`
 * Clone the repo with the following command: `git clone https://github.com/Rubberduckycooly/Sonic-1-2-2013-Decompilation.git`
 * Go into the repo you just cloned with `cd Sonic-1-2-2013-Decompilation`
 * Then run `make -j4` (-j switch is optional but will make building faster, it's based on the number of cores you have +1 so 8 cores wold be -j9)


### PR DESCRIPTION
Arch Linux tweak referenced here: https://github.com/Rubberduckycooly/Sonic-1-2-2013-Decompilation/pull/108#issuecomment-766160230

MSYS2 issue referenced here: https://github.com/Rubberduckycooly/Sonic-1-2-2013-Decompilation/pull/108#issuecomment-766161797

The executable built in MSYS2 won't work on a machine without MSYS2 installed. I fiddled around with the makefile as much as I could to fix this, I made a little progress but ran into library linking errors. It's beyond my ability.