### PR TITLE
Restored Vita to 240 vertical resolution

### DIFF
--- a/Sonic12Decomp/RetroEngine.hpp
+++ b/Sonic12Decomp/RetroEngine.hpp
@@ -77,11 +77,9 @@ typedef unsigned int uint;
 #if RETRO_PLATFORM == RETRO_VITA
 #define DEFAULT_SCREEN_XSIZE 480
 #define DEFAULT_FULLSCREEN   false
-#define SCREEN_YSIZE         (272)
 #else
 #define DEFAULT_SCREEN_XSIZE 424
 #define DEFAULT_FULLSCREEN   false
-#define SCREEN_YSIZE         (240)
 #define RETRO_USING_MOUSE
 #define RETRO_USING_TOUCH
 #endif
@@ -155,6 +153,7 @@ enum RetroGameType {
 };
 
 // General Defines
+#define SCREEN_YSIZE (240)
 #define SCREEN_CENTERY (SCREEN_YSIZE / 2)
 
 #if RETRO_PLATFORM == RETRO_WIN || RETRO_PLATFORM == RETRO_UWP


### PR DESCRIPTION
This gets rid of xeeynamo's 272 resolution for Vita and makes it use 240 like the other ports. I've tested this with Sonic 1 and Labyrinth Zone Act 3's infinite scrolling works as it should and I ran through GHZ without crashing while picking up Invincibility Monitors and going Super Sonic to test the audio change. Nothing should be broken as it's literally just a y-resolution change to make it consistent across all ports.