### PR TITLE
Small userdata refresh rate read fix

### DIFF
--- a/Sonic12Decomp/Userdata.cpp
+++ b/Sonic12Decomp/Userdata.cpp
@@ -169,7 +169,7 @@ void InitUserdata()
             Engine.windowScale = 2;
         if (!ini.GetInteger("Window", "ScreenWidth", &SCREEN_XSIZE))
             SCREEN_XSIZE = DEFAULT_SCREEN_XSIZE;
-        if (!ini.GetInteger("Window", "Refresh Rate", &Engine.refreshRate))
+        if (!ini.GetInteger("Window", "RefreshRate", &Engine.refreshRate))
             Engine.refreshRate = 60;
 
         float bv = 0, sv = 0;


### PR DESCRIPTION
This gets rid of an erroneous space in the refresh rate variable's key, allowing the user's defined refresh rate to be read instead of always defaulting to 60.