### PR TITLE
added FORCE_CASE_INSENSITIVE flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,11 @@ SOURCES = Sonic12Decomp/Animation.cpp     \
           Sonic12Decomp/String.cpp        \
           Sonic12Decomp/Text.cpp          \
           Sonic12Decomp/Userdata.cpp      \
+	  
+ifneq ($(FORCE_CASE_INSENSITIVE),)
+	CXXFLAGS_ALL += -DFORCE_CASE_INSENSITIVE
+	SOURCES += Sonic12Decomp/fcaseopen.c
+endif
 
 objects/%.o: %
 	mkdir -p $(@D)

--- a/Sonic12Decomp/Reader.hpp
+++ b/Sonic12Decomp/Reader.hpp
@@ -1,6 +1,19 @@
 #ifndef READER_H
 #define READER_H
 
+#ifdef FORCE_CASE_INSENSITIVE
+
+#include "fcaseopen.h"
+#define FileIO                                          FILE
+#define fOpen(path, mode)                               fcaseopen(path, mode)
+#define fRead(buffer, elementSize, elementCount, file)  fread(buffer, elementSize, elementCount, file)
+#define fSeek(file, offset, whence)                     fseek(file, offset, whence)
+#define fTell(file)                                     ftell(file)
+#define fClose(file)                                    fclose(file)
+#define fWrite(buffer, elementSize, elementCount, file) fwrite(buffer, elementSize, elementCount, file)
+
+#else
+
 #if RETRO_USING_SDL1 || RETRO_USING_SDL2
 #define FileIO                                          SDL_RWops
 #define fOpen(path, mode)                               SDL_RWFromFile(path, mode)
@@ -17,6 +30,8 @@
 #define fTell(file)                                     ftell(file)
 #define fClose(file)                                    fclose(file)
 #define fWrite(buffer, elementSize, elementCount, file) fwrite(buffer, elementSize, elementCount, file)
+#endif
+
 #endif
 
 struct FileInfo {

--- a/Sonic12Decomp/fcaseopen.c
+++ b/Sonic12Decomp/fcaseopen.c
@@ -1,0 +1,137 @@
+/*
+Copyright (c) 2009 Keith Bauer
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+#include "fcaseopen.h"
+
+#if !defined(_WIN32)
+#include <stdlib.h>
+#include <string.h>
+
+#include <dirent.h>
+#include <errno.h>
+#include <unistd.h>
+
+// r must have strlen(path) + 2 bytes
+static int casepath(char const *path, char *r)
+{
+    size_t l = strlen(path);
+    char *p = (char*)alloca(l + 1);
+    strcpy(p, path);
+    size_t rl = 0;
+    
+    DIR *d;
+    if (p[0] == '/')
+    {
+        d = opendir("/");
+        p = p + 1;
+    }
+    else
+    {
+        d = opendir(".");
+        r[0] = '.';
+        r[1] = 0;
+        rl = 1;
+    }
+    
+    int last = 0;
+    char *c = strsep(&p, "/");
+    while (c)
+    {
+        if (!d)
+        {
+            return 0;
+        }
+        
+        if (last)
+        {
+            closedir(d);
+            return 0;
+        }
+        
+        r[rl] = '/';
+        rl += 1;
+        r[rl] = 0;
+        
+        struct dirent *e = readdir(d);
+        while (e)
+        {
+            if (strcasecmp(c, e->d_name) == 0)
+            {
+                strcpy(r + rl, e->d_name);
+                rl += strlen(e->d_name);
+
+                closedir(d);
+                d = opendir(r);
+                
+                break;
+            }
+            
+            e = readdir(d);
+        }
+        
+        if (!e)
+        {
+            strcpy(r + rl, c);
+            rl += strlen(c);
+            last = 1;
+        }
+        
+        c = strsep(&p, "/");
+    }
+    
+    if (d) closedir(d);
+    return 1;
+}
+#endif
+
+FILE *fcaseopen(char const *path, char const *mode)
+{
+    FILE *f = fopen(path, mode);
+#if !defined(_WIN32)
+    if (!f)
+    {	    
+        char *r = (char*)alloca(strlen(path) + 2);
+        if (casepath(path, r))
+        {
+            f = fopen(r, mode);
+        }
+    }
+#endif
+    return f;
+}
+
+void casechdir(char const *path)
+{
+#if !defined(_WIN32)
+    char *r = (char*)alloca(strlen(path) + 2);
+    if (casepath(path, r))
+    {
+        chdir(r);
+    }
+    else
+    {
+        errno = ENOENT;
+    }
+#else
+    chdir(path);
+#endif
+}

--- a/Sonic12Decomp/fcaseopen.h
+++ b/Sonic12Decomp/fcaseopen.h
@@ -1,0 +1,40 @@
+/*
+Copyright (c) 2009 Keith Bauer
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+#ifndef fcaseopen_h
+#define fcaseopen_h
+
+#include <stdio.h>
+
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
+extern FILE *fcaseopen(char const *path, char const *mode);
+
+extern void casechdir(char const *path);
+
+#if defined(__cplusplus)
+}
+#endif
+
+#endif


### PR DESCRIPTION
Hi, first of all thanks for the great work you've done, I couldn't thank you enough.
I noticed that on Linux I ran into problems when running Sonic 1 from the Data folder directly without using datafiles... the game froze as soon as I tried playing a level.
It turns out that there are case sensitivity problems with the file paths requested by the game, that weren't an issue at all on the operating systems the Retro Engine was developed for (as none of them use case sensitive filesystems), but do cause issues on operating systems using case sensitive filesystems such as Linux.
I've fixed the issue by adding a FORCE_CASE_INSENSITIVE build flag to the Makefile, which, if enabled, compiles in a fcaseopen() function that acts as a "case-insensitive" fopen(), and makes Reader.cpp use that instead of standard fopen().

make FORCE_CASE_INSENSITIVE=1 will make a "case-insensitive" build.