### PR TITLE
UWP Fixes

### DIFF
--- a/Sonic12Decomp/RetroEngine.cpp
+++ b/Sonic12Decomp/RetroEngine.cpp
@@ -255,8 +255,22 @@ void RetroEngine::Init()
 
     InitUserdata();
     char dest[0x200];
+#if RETRO_PLATFORM == RETRO_UWP
+    static char resourcePath[256] = { 0 };
+
+    if (strlen(resourcePath) == 0) {
+        auto folder = winrt::Windows::Storage::ApplicationData::Current().LocalFolder();
+        auto path   = to_string(folder.Path());
+
+        std::copy(path.begin(), path.end(), resourcePath);
+    }
+
+    strcpy(dest, resourcePath);
+    strcat(dest, "\\Data.rsdk");
+#else
     StrCopy(dest, BASE_PATH);
     StrAdd(dest, Engine.dataFile);
+#endif
     CheckRSDKFile(dest);
     InitNativeObjectSystem();
 

--- a/Sonic12Decomp/main.cpp
+++ b/Sonic12Decomp/main.cpp
@@ -6,7 +6,8 @@ int main(int argc, char *argv[])
         if (StrComp(argv[i], "UsingCWD"))
             usingCWD = true;
     }
-
+    
+    SDL_SetHint(SDL_HINT_WINRT_HANDLE_BACK_BUTTON, "1");
     Engine.Init();
 #if RETRO_USING_SDL2
     controllerInit(0);

--- a/Sonic1Decomp.UWP/Sonic1Decomp.UWP.vcxproj
+++ b/Sonic1Decomp.UWP/Sonic1Decomp.UWP.vcxproj
@@ -154,16 +154,6 @@
     </AppxManifest>
   </ItemGroup>
   <ItemGroup>
-    <None Include="Data.rsdk">
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</DeploymentContent>
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</DeploymentContent>
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">true</DeploymentContent>
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">true</DeploymentContent>
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">true</DeploymentContent>
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">true</DeploymentContent>
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</DeploymentContent>
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</DeploymentContent>
-    </None>
     <None Include="packages.config" />
     <None Include="PropertySheet.props" />
     <Text Include="readme.txt">

--- a/Sonic2Decomp.UWP/Sonic2Decomp.UWP.vcxproj
+++ b/Sonic2Decomp.UWP/Sonic2Decomp.UWP.vcxproj
@@ -198,16 +198,6 @@
     <Image Include="Assets\WideTile.scale-200.png" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="Data.rsdk">
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</DeploymentContent>
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</DeploymentContent>
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">true</DeploymentContent>
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">true</DeploymentContent>
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">true</DeploymentContent>
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">true</DeploymentContent>
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</DeploymentContent>
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</DeploymentContent>
-    </None>
     <None Include="packages.config" />
     <None Include="PropertySheet.props" />
     <Text Include="readme.txt">

--- a/dependencies/windows-uwp/dependencies.txt
+++ b/dependencies/windows-uwp/dependencies.txt
@@ -1,3 +1,11 @@
-Download the latest SDL2 source tarball from https://www.libsdl.org/download-2.0.php, and extract it's contents to a folder called `SDL2`. 
+SDL2: https://www.libsdl.org/download-2.0.php
+download the appropriate development library for your compiler and unzip it in "./SDL2/"
 
-If you wish to build ARM/ARM64 architecture variants, be sure to retarget and build libogg and libvorbis for these platforms. 
+SDL1 (optional, use SDL2 if you're unsure): https://libsdl.org/download-1.2.php
+download the appropriate development library for your compiler and unzip it in "./SDL1/"
+
+libogg: https://xiph.org/downloads/ (libogg)
+download libogg and unzip it in "./libogg/", then build the static library
+
+libvorbis: https://xiph.org/downloads/ (libvorbis)
+download libvorbis and unzip it in "./libvorbis/", then build the VS2010 static library (win32/VS2010/vorbis_static.sln)


### PR DESCRIPTION
Fixed a bug on Xbox One where pressing B would exit from the app.
Remove the data.rsdk file from the output appx package and instead read it from the apps local data folder. This is done in order to allow automatic builds in future
Add full list of UWP dependencies