### PR TITLE
Multiple additional scaling modes

### DIFF
--- a/Sonic12Decomp/Drawing.cpp
+++ b/Sonic12Decomp/Drawing.cpp
@@ -167,7 +167,6 @@ void RenderRenderDevice()
         case 3: bilinearScaling = true; break;    // regular old bilinear
     }
 
-
     SDL_GetWindowSize(Engine.window, &Engine.windowXSize, &Engine.windowYSize);
     float screenxsize = SCREEN_XSIZE;
     float screenysize = SCREEN_YSIZE;
@@ -206,10 +205,9 @@ void RenderRenderDevice()
         texTarget = SDL_CreateTexture(Engine.renderer, SDL_PIXELFORMAT_RGB565, SDL_TEXTUREACCESS_TARGET, SCREEN_XSIZE * scale, SCREEN_YSIZE * scale);
 
         // keep aspect
-        float aspectScale      = std::fminf(Engine.windowYSize / screenysize, Engine.windowXSize / screenxsize);
-        if (integerScaling) {
-            aspectScale = std::floor(aspectScale);
-        }
+        float aspectScale = (integerScaling) ? std::fminf(
+            std::floor(Engine.windowYSize / screenysize), std::floor(Engine.windowXSize / screenxsize))
+        : std::fminf(Engine.windowYSize / screenysize, Engine.windowXSize / screenxsize);
         float xoffset          = (Engine.windowXSize - (screenxsize * aspectScale)) / 2;
         float yoffset          = (Engine.windowYSize - (screenysize * aspectScale)) / 2;
         destScreenPos_scaled.x = std::round(xoffset);

--- a/Sonic12Decomp/Drawing.cpp
+++ b/Sonic12Decomp/Drawing.cpp
@@ -159,12 +159,12 @@ void RenderRenderDevice()
     bool bilinearScaling = false;
 
     #if RETRO_PLATFORM == RETRO_VITA // Vita crashes with the switchcase for some reason
-    if (Engine.scalingMode != (0 || 1 || 2 || 3))
-        Engine.scalingMode = RETRO_DEFAULTSCALINGMODE;
-    if (Engine.scalingMode == 1)
-        integerScaling = true;
-    if (Engine.scalingMode == 3)
-        bilinearScaling = true;
+    //if (Engine.scalingMode != (0 || 1 || 2 || 3))
+    //    Engine.scalingMode = RETRO_DEFAULTSCALINGMODE;
+    //if (Engine.scalingMode == 1)
+    //    integerScaling = true;
+    //if (Engine.scalingMode == 3)
+    //    bilinearScaling = true;
     #else
     switch (Engine.scalingMode) {
         // reset to default if value is invalid.
@@ -215,9 +215,9 @@ void RenderRenderDevice()
 
         // keep aspect
         float aspectScale = std::fminf(Engine.windowYSize / screenysize, Engine.windowXSize / screenxsize);
-        if (integerScaling) {
+        //if (integerScaling) {
             aspectScale = std::floor(aspectScale);
-        }
+        //}
         float xoffset          = (Engine.windowXSize - (screenxsize * aspectScale)) / 2;
         float yoffset          = (Engine.windowYSize - (screenysize * aspectScale)) / 2;
         destScreenPos_scaled.x = std::round(xoffset);

--- a/Sonic12Decomp/Drawing.cpp
+++ b/Sonic12Decomp/Drawing.cpp
@@ -158,6 +158,14 @@ void RenderRenderDevice()
     // enable bilinear scaling, which just disables the fancy upscaling that enhanced scaling does.
     bool bilinearScaling = false;
 
+    #if RETRO_PLATFORM == RETRO_VITA // Vita crashes with the switchcase for some reason
+    if (Engine.scalingMode != (0 || 1 || 2 || 3))
+        Engine.scalingMode = RETRO_DEFAULTSCALINGMODE;
+    if (Engine.scalingMode == 1)
+        integerScaling = true;
+    if (Engine.scalingMode == 3)
+        bilinearScaling = true;
+    #else
     switch (Engine.scalingMode) {
         // reset to default if value is invalid.
         default: Engine.scalingMode = RETRO_DEFAULTSCALINGMODE; break;
@@ -166,6 +174,7 @@ void RenderRenderDevice()
         case 2: break;                            // sharp bilinear
         case 3: bilinearScaling = true; break;    // regular old bilinear
     }
+    #endif
 
     SDL_GetWindowSize(Engine.window, &Engine.windowXSize, &Engine.windowYSize);
     float screenxsize = SCREEN_XSIZE;
@@ -207,7 +216,7 @@ void RenderRenderDevice()
         // keep aspect
         float aspectScale = std::fminf(Engine.windowYSize / screenysize, Engine.windowXSize / screenxsize);
         if (integerScaling) {
-            aspectScale = int(aspectScale);
+            aspectScale = std::floor(aspectScale);
         }
         float xoffset          = (Engine.windowXSize - (screenxsize * aspectScale)) / 2;
         float yoffset          = (Engine.windowYSize - (screenysize * aspectScale)) / 2;

--- a/Sonic12Decomp/Drawing.cpp
+++ b/Sonic12Decomp/Drawing.cpp
@@ -205,9 +205,10 @@ void RenderRenderDevice()
         texTarget = SDL_CreateTexture(Engine.renderer, SDL_PIXELFORMAT_RGB565, SDL_TEXTUREACCESS_TARGET, SCREEN_XSIZE * scale, SCREEN_YSIZE * scale);
 
         // keep aspect
-        float aspectScale = (integerScaling) ? std::fminf(
-            std::floor(Engine.windowYSize / screenysize), std::floor(Engine.windowXSize / screenxsize))
-        : std::fminf(Engine.windowYSize / screenysize, Engine.windowXSize / screenxsize);
+        float aspectScale = std::fminf(Engine.windowYSize / screenysize, Engine.windowXSize / screenxsize);
+        if (integerScaling) {
+            aspectScale = int(aspectScale);
+        }
         float xoffset          = (Engine.windowXSize - (screenxsize * aspectScale)) / 2;
         float yoffset          = (Engine.windowYSize - (screenysize * aspectScale)) / 2;
         destScreenPos_scaled.x = std::round(xoffset);

--- a/Sonic12Decomp/RetroEngine.hpp
+++ b/Sonic12Decomp/RetroEngine.hpp
@@ -77,13 +77,14 @@ typedef unsigned int uint;
 #if RETRO_PLATFORM == RETRO_VITA
 #define DEFAULT_SCREEN_XSIZE 480
 #define DEFAULT_FULLSCREEN   false
-#define RETRO_DEFAULTSCALINGMODE 1
+#define RETRO_DEFAULTSCALINGMODE 0
 #else
 #define DEFAULT_SCREEN_XSIZE 424
 #define DEFAULT_FULLSCREEN   false
 #define RETRO_USING_MOUSE
 #define RETRO_USING_TOUCH
-// set this to 1 (integer scale) for other platforms that don't support bilinear and don't have an even screen size.
+// set this to 1 (integer scale) for other platforms that don't support bilinear and don't have an even screen size,
+// or 0 if you get a crash with 1 like on Vita lol
 #define RETRO_DEFAULTSCALINGMODE 2
 #endif
 

--- a/Sonic12Decomp/RetroEngine.hpp
+++ b/Sonic12Decomp/RetroEngine.hpp
@@ -77,11 +77,14 @@ typedef unsigned int uint;
 #if RETRO_PLATFORM == RETRO_VITA
 #define DEFAULT_SCREEN_XSIZE 480
 #define DEFAULT_FULLSCREEN   false
+#define RETRO_DEFAULTSCALINGMODE 1
 #else
 #define DEFAULT_SCREEN_XSIZE 424
 #define DEFAULT_FULLSCREEN   false
 #define RETRO_USING_MOUSE
 #define RETRO_USING_TOUCH
+// set this to 1 (integer scale) for other platforms that don't support bilinear and don't have an even screen size.
+#define RETRO_DEFAULTSCALINGMODE 2
 #endif
 
 #ifndef BASE_PATH
@@ -289,7 +292,7 @@ public:
     bool startFullScreen  = false; // if should start as fullscreen
     bool borderless       = false;
     bool vsync            = false;
-    bool enhancedScaling  = true; // enable enhanced scaling
+    int scalingMode       = RETRO_DEFAULTSCALINGMODE;
     int windowScale       = 2;
     int refreshRate       = 60; // user-picked screen update rate
     int screenRefreshRate = 60; // hardware screen update rate

--- a/Sonic12Decomp/Userdata.cpp
+++ b/Sonic12Decomp/Userdata.cpp
@@ -53,7 +53,7 @@ void InitUserdata()
         ini.SetBool("Window", "FullScreen", Engine.startFullScreen = DEFAULT_FULLSCREEN);
         ini.SetBool("Window", "Borderless", Engine.borderless = false);
         ini.SetBool("Window", "VSync", Engine.vsync = false);
-        ini.SetBool("Window", "EnhancedScaling", Engine.enhancedScaling = true);
+        ini.SetInteger("Window", "ScalingMode", Engine.scalingMode = RETRO_DEFAULTSCALINGMODE);
         ini.SetInteger("Window", "WindowScale", Engine.windowScale = 2);
         ini.SetInteger("Window", "ScreenWidth", SCREEN_XSIZE = DEFAULT_SCREEN_XSIZE);
         ini.SetInteger("Window", "RefreshRate", Engine.refreshRate = 60);
@@ -163,8 +163,8 @@ void InitUserdata()
             Engine.borderless = false;
         if (!ini.GetBool("Window", "VSync", &Engine.vsync))
             Engine.vsync = false;
-        if (!ini.GetBool("Window", "EnhancedScaling", &Engine.enhancedScaling))
-            Engine.enhancedScaling = true;
+        if (!ini.GetInteger("Window", "ScalingMode", &Engine.scalingMode))
+            Engine.scalingMode = RETRO_DEFAULTSCALINGMODE;
         if (!ini.GetInteger("Window", "WindowScale", &Engine.windowScale))
             Engine.windowScale = 2;
         if (!ini.GetInteger("Window", "ScreenWidth", &SCREEN_XSIZE))
@@ -391,8 +391,9 @@ void writeSettings()
     ini.SetBool("Window", "Borderless", Engine.borderless);
     ini.SetComment("Window", "VSComment", "Determines if VSync will be active or not");
     ini.SetBool("Window", "VSync", Engine.vsync);
-    ini.SetComment("Window", "ESComment", "Determines if Enhanced Scaling will be active or not. Only affects non-multiple resolutions.");
-    ini.SetBool("Window", "EnhancedScaling", Engine.enhancedScaling);
+    ini.SetComment("Window", "SMComment", "Determines what scaling is used. 0 is nearest neighbour, 1 is integer scale, 2 is sharp bilinear, and 3 is regular bilinear.");
+    ini.SetComment("Window", "SMWarning", "Note: Not all scaling options work correctly on certain platforms, as they don't support bilinear filtering.");
+    ini.SetInteger("Window", "ScalingMode", Engine.scalingMode);
     ini.SetComment("Window", "WSComment", "How big the window will be");
     ini.SetInteger("Window", "WindowScale", Engine.windowScale);
     ini.SetComment("Window", "SWComment", "How wide the base screen will be in pixels");


### PR DESCRIPTION
Changed scaling mode option to an integer value to accommodate more than two scaling options, and added regular bilinear and integer scaling modes. Vita version's default scaling mode has been changed to nearest neighbour as the other scaling modes don't work right in one way or another (integer scale and bilinear literally crash it. I've spent over two hours trying to figure out why, with no luck, so I just forced the option to reset if you select those).