### PR TITLE
Remove Superfluous Window Position

### DIFF
--- a/Sonic12Decomp/Drawing.cpp
+++ b/Sonic12Decomp/Drawing.cpp
@@ -85,7 +85,6 @@ int InitRenderDevice()
     }
 
     SDL_SetWindowResizable(Engine.window, SDL_FALSE);
-    SDL_SetWindowPosition(Engine.window, SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED);
 
     SDL_DisplayMode disp;
     if (SDL_GetDisplayMode(0, 0, &disp) == 0) {


### PR DESCRIPTION
Position was already set when the window was created. This also fixes that weird letterboxing issue on mingw.