### PR TITLE
Fix the Linux makefile

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -98,4 +98,4 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: v4-linux
-          path: bin/sonic2013
+          path: bin

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,13 @@
 CXXFLAGS_ALL = $(shell pkg-config --cflags --static sdl2 vorbisfile vorbis) $(CXXFLAGS) \
                -DBASE_PATH='"$(BASE_PATH)"'
+CXXFLAGS += -Idependencies/all/filesystem \
+            -Idependencies/all/upng
 
 LDFLAGS_ALL = $(LDFLAGS)
 LIBS_ALL = $(shell pkg-config --libs --static sdl2 vorbisfile vorbis) -pthread $(LIBS)
 
-SOURCES = Sonic12Decomp/Animation.cpp     \
+SOURCES = dependencies/all/upng/upng.cpp  \
+          Sonic12Decomp/Animation.cpp     \
           Sonic12Decomp/Audio.cpp         \
           Sonic12Decomp/Collision.cpp     \
           Sonic12Decomp/Debug.cpp         \
@@ -24,6 +27,7 @@ SOURCES = Sonic12Decomp/Animation.cpp     \
           Sonic12Decomp/Scene3D.cpp       \
           Sonic12Decomp/Script.cpp        \
           Sonic12Decomp/Sprite.cpp        \
+          Sonic12Decomp/StartMenu.cpp     \
           Sonic12Decomp/String.cpp        \
           Sonic12Decomp/Text.cpp          \
           Sonic12Decomp/Userdata.cpp      \

--- a/Sonic12Decomp/RetroEngine.hpp
+++ b/Sonic12Decomp/RetroEngine.hpp
@@ -35,6 +35,7 @@ typedef unsigned int uint;
 #define RETRO_WP7      (6)
 // Custom Platforms start here
 #define RETRO_UWP (7)
+#define RETRO_LINUX (8)
 
 // Platform types (Game manages platform-specific code such as HUD position using this rather than the above)
 #define RETRO_STANDARD (0)
@@ -70,6 +71,10 @@ typedef unsigned int uint;
 #else
 #error "Unknown Apple platform"
 #endif
+
+#elif defined __linux__
+#define RETRO_PLATFORM   (RETRO_LINUX)
+#define RETRO_DEVICETYPE (RETRO_STANDARD)
 #endif
 
 #define DEFAULT_SCREEN_XSIZE 424
@@ -83,7 +88,7 @@ typedef unsigned int uint;
 #define BASE_PATH ""
 #endif
 
-#if RETRO_PLATFORM == RETRO_WIN || RETRO_PLATFORM == RETRO_OSX || RETRO_PLATFORM == RETRO_UWP
+#if RETRO_PLATFORM == RETRO_WIN || RETRO_PLATFORM == RETRO_OSX || RETRO_PLATFORM == RETRO_UWP || RETRO_PLATFORM == RETRO_LINUX
 #define RETRO_USING_SDL1 (0)
 #define RETRO_USING_SDL2 (1)
 #else // Since its an else & not an elif these platforms probably aren't supported yet


### PR DESCRIPTION
Also:
- makes the Linux autobuild use the whole bin folder instead of just the `sonic2013` file (just kinda future proofing as it *still* only builds the single file)
- defines RETRO_LINUX as the fallback it was relying on was removed in 267dac6