### PR TITLE
Fix file loading on case-sensitive filesystems

### DIFF
--- a/Sonic12Decomp/Reader.cpp
+++ b/Sonic12Decomp/Reader.cpp
@@ -63,7 +63,7 @@ bool CheckRSDKFile(const char *filePath)
 
         fClose(cFileHandle);
         cFileHandle = NULL;
-        if (LoadFile("ByteCode/GlobalCode.bin", &info)) {
+        if (LoadFile("Bytecode/GlobalCode.bin", &info)) {
             Engine.usingBytecode = true;
             CloseFile();
         }
@@ -72,7 +72,7 @@ bool CheckRSDKFile(const char *filePath)
     else {
         Engine.usingDataFile = false;
         cFileHandle = NULL;
-        if (LoadFile("ByteCode/GlobalCode.bin", &info)) {
+        if (LoadFile("Bytecode/GlobalCode.bin", &info)) {
             Engine.usingBytecode = true;
             CloseFile();
         }

--- a/Sonic12Decomp/Script.cpp
+++ b/Sonic12Decomp/Script.cpp
@@ -2145,11 +2145,11 @@ void LoadBytecode(int stageListID, int scriptID)
         case STAGELIST_REGULAR:
         case STAGELIST_BONUS:
         case STAGELIST_SPECIAL:
-            StrCopy(scriptPath, "ByteCode/");
+            StrCopy(scriptPath, "Bytecode/");
             StrAdd(scriptPath, stageList[stageListID][stageListPosition].folder);
             StrAdd(scriptPath, ".bin");
             break;
-        case 4: StrCopy(scriptPath, "ByteCode/GlobalCode.bin"); break;
+        case 4: StrCopy(scriptPath, "Bytecode/GlobalCode.bin"); break;
         default: break;
     }
 


### PR DESCRIPTION
By default retrun outputs a `Data/` and a `Bytecode/` folder. 

While running on Linux, the game tries to load a `ByteCode/` folder, with an uppercase C, causing it to freeze when loading any save.

This commit just replaces ByteCode with Bytecode.