### PR TITLE
Fix bytecode loading on case-sensitive filesystems

### DIFF
--- a/Sonic12Decomp/Reader.cpp
+++ b/Sonic12Decomp/Reader.cpp
@@ -81,7 +81,7 @@ bool CheckRSDKFile(const char *filePath)
         cFileHandle = NULL;
         if (dataMode)
             return true;
-        if (LoadFile("ByteCode/GlobalCode.bin", &info)) {
+        if (LoadFile("Bytecode/GlobalCode.bin", &info)) {
             Engine.usingBytecode = true;
             CloseFile();
         }
@@ -97,7 +97,7 @@ bool CheckRSDKFile(const char *filePath)
         if (dataMode)
             return false;
 
-        if (LoadFile("ByteCode/GlobalCode.bin", &info)) {
+        if (LoadFile("Bytecode/GlobalCode.bin", &info)) {
             Engine.usingBytecode = true;
             CloseFile();
         }

--- a/Sonic12Decomp/Script.cpp
+++ b/Sonic12Decomp/Script.cpp
@@ -2200,11 +2200,11 @@ void LoadBytecode(int stageListID, int scriptID)
         case STAGELIST_REGULAR:
         case STAGELIST_BONUS:
         case STAGELIST_SPECIAL:
-            StrCopy(scriptPath, "ByteCode/");
+            StrCopy(scriptPath, "Bytecode/");
             StrAdd(scriptPath, stageList[stageListID][stageListPosition].folder);
             StrAdd(scriptPath, ".bin");
             break;
-        case 4: StrCopy(scriptPath, "ByteCode/GlobalCode.bin"); break;
+        case 4: StrCopy(scriptPath, "Bytecode/GlobalCode.bin"); break;
         default: break;
     }
 


### PR DESCRIPTION
(same as #161, now targeting 1.2.0 branch)

When launching the decomp on Data Folder mode, it tries to load the Byte**C**ode/ folder. On Windows this does not cause any problems, because file loading is case-insensitive. But on Linux it fails to find those files, and when loading a save the game freezes.

By default retrun outputs a Data/ and a Bytecode/ folder, so new users will probably use those folder names when trying to install mods, facing this problem