### PR TITLE
Fix broken Makefile with CXXFLAGS set

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 CXXFLAGS_ALL = $(shell pkg-config --cflags --static sdl2 vorbisfile vorbis) $(CXXFLAGS) \
-               -DBASE_PATH='"$(BASE_PATH)"'
-CXXFLAGS += -Idependencies/all/filesystem \
-            -Idependencies/all/upng
+               -DBASE_PATH='"$(BASE_PATH)"' \
+               -Idependencies/all/filesystem \
+               -Idependencies/all/upng
 
 LDFLAGS_ALL = $(LDFLAGS)
 LIBS_ALL = $(shell pkg-config --libs --static sdl2 vorbisfile vorbis) -pthread $(LIBS)


### PR DESCRIPTION
I improperly used `CXXFLAGS +=` when adding the dependencies and, as a result, broke building if, say `make CXXFLAGS=-g` is used.

Instead, I have now added the dependencies under CXXFLAGS_ALL, which should've been that in the first place.