### PR TITLE
Fix filename case of GameConfig.bin in Audio.cpp

### DIFF
--- a/Sonic12Decomp/Audio.cpp
+++ b/Sonic12Decomp/Audio.cpp
@@ -89,7 +89,7 @@ int InitAudioPlayback()
     byte fileBuffer = 0;
     int fileBuffer2 = 0;
 
-    if (LoadFile("Data/Game/Gameconfig.bin", &info)) {
+    if (LoadFile("Data/Game/GameConfig.bin", &info)) {
         infoStore = info;
 
         FileRead(&fileBuffer, 1);


### PR DESCRIPTION
For some reason, `GameConfig.bin` was written as `Gameconfig.bin` here (all other instances properly use the former), which resulted in sound effects not playing if running on a case sensitive filesystem (e.g. Linux)