### PR TITLE
Add support for multiple game controllers (SDL 2 only)

### DIFF
--- a/Sonic12Decomp/Input.cpp
+++ b/Sonic12Decomp/Input.cpp
@@ -61,6 +61,19 @@ bool getControllerButton(byte buttonID)
 
     return false;
 }
+
+void controllerInit(byte controllerID)
+{
+    inputType  = 1;
+    controller = SDL_GameControllerOpen(controllerID);
+}
+
+void controllerClose(byte controllerID)
+{
+    if (controllerID >= 2)
+        return;
+    inputType = 0;
+}
 #endif
 
 void ProcessInput()

--- a/Sonic12Decomp/Input.cpp
+++ b/Sonic12Decomp/Input.cpp
@@ -1,5 +1,8 @@
 #include "RetroEngine.hpp"
 
+#include <algorithm>
+#include <vector>
+
 InputData keyPress = InputData();
 InputData keyDown  = InputData();
 
@@ -20,7 +23,7 @@ int LTRIGGER_DEADZONE = 20000;
 int RTRIGGER_DEADZONE = 20000;
 
 #if RETRO_USING_SDL2
-SDL_GameController *controller = nullptr;
+std::vector<SDL_GameController*> controllers;
 #endif
 
 #if RETRO_USING_SDL1
@@ -32,47 +35,95 @@ SDL_Joystick *controller = nullptr;
 #if RETRO_USING_SDL2
 bool getControllerButton(byte buttonID)
 {
-    if (SDL_GameControllerGetButton(controller, (SDL_GameControllerButton)buttonID)) {
-        return true;
-    }
-    else {
+    bool pressed = false;
+
+    for (int i = 0; i < controllers.size(); ++i)
+    {
+        SDL_GameController* controller = controllers[i];
+
+        if (SDL_GameControllerGetButton(controller, (SDL_GameControllerButton)buttonID)) {
+            pressed |= true;
+            continue;
+        }
+        else {
+            switch (buttonID) {
+                default: break;
+                case SDL_CONTROLLER_BUTTON_DPAD_UP:
+                    pressed |= SDL_GameControllerGetAxis(controller, SDL_CONTROLLER_AXIS_LEFTY) < -LSTICK_DEADZONE;
+                    continue;
+                case SDL_CONTROLLER_BUTTON_DPAD_DOWN:
+                    pressed |= SDL_GameControllerGetAxis(controller, SDL_CONTROLLER_AXIS_LEFTY) > LSTICK_DEADZONE;
+                    continue;
+                case SDL_CONTROLLER_BUTTON_DPAD_LEFT:
+                    pressed |= SDL_GameControllerGetAxis(controller, SDL_CONTROLLER_AXIS_LEFTX) < -LSTICK_DEADZONE;
+                    continue;
+                case SDL_CONTROLLER_BUTTON_DPAD_RIGHT:
+                    pressed |= SDL_GameControllerGetAxis(controller, SDL_CONTROLLER_AXIS_LEFTX) > LSTICK_DEADZONE;
+                    continue;
+            }
+        }
+
         switch (buttonID) {
             default: break;
-            case SDL_CONTROLLER_BUTTON_DPAD_UP: return SDL_GameControllerGetAxis(controller, SDL_CONTROLLER_AXIS_LEFTY) < -LSTICK_DEADZONE;
-            case SDL_CONTROLLER_BUTTON_DPAD_DOWN: return SDL_GameControllerGetAxis(controller, SDL_CONTROLLER_AXIS_LEFTY) > LSTICK_DEADZONE;
-            case SDL_CONTROLLER_BUTTON_DPAD_LEFT: return SDL_GameControllerGetAxis(controller, SDL_CONTROLLER_AXIS_LEFTX) < -LSTICK_DEADZONE;
-            case SDL_CONTROLLER_BUTTON_DPAD_RIGHT: return SDL_GameControllerGetAxis(controller, SDL_CONTROLLER_AXIS_LEFTX) > LSTICK_DEADZONE;
+            case SDL_CONTROLLER_BUTTON_ZL:
+                pressed |= SDL_GameControllerGetAxis(controller, SDL_CONTROLLER_AXIS_TRIGGERLEFT) > LTRIGGER_DEADZONE;
+                continue;
+            case SDL_CONTROLLER_BUTTON_ZR:
+                pressed |= SDL_GameControllerGetAxis(controller, SDL_CONTROLLER_AXIS_TRIGGERRIGHT) > RTRIGGER_DEADZONE;
+                continue;
+            case SDL_CONTROLLER_BUTTON_LSTICK_UP:
+                pressed |= SDL_GameControllerGetAxis(controller, SDL_CONTROLLER_AXIS_LEFTY) < -LSTICK_DEADZONE;
+                continue;
+            case SDL_CONTROLLER_BUTTON_LSTICK_DOWN:
+                pressed |= SDL_GameControllerGetAxis(controller, SDL_CONTROLLER_AXIS_LEFTY) > LSTICK_DEADZONE;
+                continue;
+            case SDL_CONTROLLER_BUTTON_LSTICK_LEFT:
+                pressed |= SDL_GameControllerGetAxis(controller, SDL_CONTROLLER_AXIS_LEFTX) < -LSTICK_DEADZONE;
+                continue;
+            case SDL_CONTROLLER_BUTTON_LSTICK_RIGHT:
+                pressed |= SDL_GameControllerGetAxis(controller, SDL_CONTROLLER_AXIS_LEFTX) > LSTICK_DEADZONE;
+                continue;
+            case SDL_CONTROLLER_BUTTON_RSTICK_UP:
+                pressed |= SDL_GameControllerGetAxis(controller, SDL_CONTROLLER_AXIS_RIGHTY) < -RSTICK_DEADZONE;
+                continue;
+            case SDL_CONTROLLER_BUTTON_RSTICK_DOWN:
+                pressed |= SDL_GameControllerGetAxis(controller, SDL_CONTROLLER_AXIS_RIGHTY) > RSTICK_DEADZONE;
+                continue;
+            case SDL_CONTROLLER_BUTTON_RSTICK_LEFT:
+                pressed |= SDL_GameControllerGetAxis(controller, SDL_CONTROLLER_AXIS_RIGHTX) < -RSTICK_DEADZONE;
+                continue;
+            case SDL_CONTROLLER_BUTTON_RSTICK_RIGHT:
+                pressed |= SDL_GameControllerGetAxis(controller, SDL_CONTROLLER_AXIS_RIGHTX) > RSTICK_DEADZONE;
+                continue;
         }
     }
 
-    switch (buttonID) {
-        default: break;
-        case SDL_CONTROLLER_BUTTON_ZL: return SDL_GameControllerGetAxis(controller, SDL_CONTROLLER_AXIS_TRIGGERLEFT) > LTRIGGER_DEADZONE;
-        case SDL_CONTROLLER_BUTTON_ZR: return SDL_GameControllerGetAxis(controller, SDL_CONTROLLER_AXIS_TRIGGERRIGHT) > RTRIGGER_DEADZONE;
-        case SDL_CONTROLLER_BUTTON_LSTICK_UP: return SDL_GameControllerGetAxis(controller, SDL_CONTROLLER_AXIS_LEFTY) < -LSTICK_DEADZONE;
-        case SDL_CONTROLLER_BUTTON_LSTICK_DOWN: return SDL_GameControllerGetAxis(controller, SDL_CONTROLLER_AXIS_LEFTY) > LSTICK_DEADZONE;
-        case SDL_CONTROLLER_BUTTON_LSTICK_LEFT: return SDL_GameControllerGetAxis(controller, SDL_CONTROLLER_AXIS_LEFTX) < -LSTICK_DEADZONE;
-        case SDL_CONTROLLER_BUTTON_LSTICK_RIGHT: return SDL_GameControllerGetAxis(controller, SDL_CONTROLLER_AXIS_LEFTX) > LSTICK_DEADZONE;
-        case SDL_CONTROLLER_BUTTON_RSTICK_UP: return SDL_GameControllerGetAxis(controller, SDL_CONTROLLER_AXIS_RIGHTY) < -RSTICK_DEADZONE;
-        case SDL_CONTROLLER_BUTTON_RSTICK_DOWN: return SDL_GameControllerGetAxis(controller, SDL_CONTROLLER_AXIS_RIGHTY) > RSTICK_DEADZONE;
-        case SDL_CONTROLLER_BUTTON_RSTICK_LEFT: return SDL_GameControllerGetAxis(controller, SDL_CONTROLLER_AXIS_RIGHTX) < -RSTICK_DEADZONE;
-        case SDL_CONTROLLER_BUTTON_RSTICK_RIGHT: return SDL_GameControllerGetAxis(controller, SDL_CONTROLLER_AXIS_RIGHTX) > RSTICK_DEADZONE;
-    }
-
-    return false;
+    return pressed;
 }
 
 void controllerInit(byte controllerID)
 {
-    inputType  = 1;
-    controller = SDL_GameControllerOpen(controllerID);
+    SDL_GameController* controller = SDL_GameControllerOpen(controllerID);
+    if (controller)
+    {
+        controllers.push_back(controller);
+        inputType  = 1;
+    }
 }
 
 void controllerClose(byte controllerID)
 {
-    if (controllerID >= 2)
-        return;
-    inputType = 0;
+    SDL_GameController* controller = SDL_GameControllerFromInstanceID(controllerID);
+    if (controller)
+    {
+        SDL_GameControllerClose(controller);
+        controllers.erase(std::remove(controllers.begin(), controllers.end(), controller), controllers.end());
+    }
+
+    if (controllers.empty())
+    {
+        inputType = 0;
+    }
 }
 #endif
 

--- a/Sonic12Decomp/Input.hpp
+++ b/Sonic12Decomp/Input.hpp
@@ -75,8 +75,6 @@ extern int LTRIGGER_DEADZONE;
 extern int RTRIGGER_DEADZONE;
 
 #if RETRO_USING_SDL2
-extern SDL_GameController *controller;
-
 // Easier this way
 enum ExtraSDLButtons {
     SDL_CONTROLLER_BUTTON_ZL = SDL_CONTROLLER_BUTTON_MAX + 1,
@@ -92,18 +90,8 @@ enum ExtraSDLButtons {
     SDL_CONTROLLER_BUTTON_MAX_EXTRA,
 };
 
-inline void controllerInit(byte controllerID)
-{
-    inputType  = 1;
-    controller = SDL_GameControllerOpen(controllerID);
-};
-
-inline void controllerClose(byte controllerID)
-{
-    if (controllerID >= 2)
-        return;
-    inputType = 0;
-}
+void controllerInit(byte controllerID);
+void controllerClose(byte controllerID);
 #endif
 
 #if RETRO_USING_SDL1

--- a/Sonic12Decomp/RetroEngine.cpp
+++ b/Sonic12Decomp/RetroEngine.cpp
@@ -40,8 +40,8 @@ bool processEvents()
                     case SDL_WINDOWEVENT_CLOSE: return false;
                 }
                 break;
-            case SDL_CONTROLLERDEVICEADDED: controllerInit(SDL_NumJoysticks() - 1); break;
-            case SDL_CONTROLLERDEVICEREMOVED: controllerClose(SDL_NumJoysticks() - 1); break;
+            case SDL_CONTROLLERDEVICEADDED: controllerInit(Engine.sdlEvents.cdevice.which); break;
+            case SDL_CONTROLLERDEVICEREMOVED: controllerClose(Engine.sdlEvents.cdevice.which); break;
             case SDL_WINDOWEVENT_CLOSE:
                 if (Engine.window) {
                     SDL_DestroyWindow(Engine.window);

--- a/Sonic12Decomp/main.cpp
+++ b/Sonic12Decomp/main.cpp
@@ -9,9 +9,6 @@ int main(int argc, char *argv[])
     
     SDL_SetHint(SDL_HINT_WINRT_HANDLE_BACK_BUTTON, "1");
     Engine.Init();
-#if RETRO_USING_SDL2
-    controllerInit(0);
-#endif
     Engine.Run();
 
     return 0;


### PR DESCRIPTION
This adds support for correctly handling multiple game controllers being present at the same time. Meaning you can grab any one of all connected controllers at random and the game will recognize its inputs. You could even use the D pad on one controller while pressing A/B on another one if you wanted to. But the main motivation is for things to work correctly in case you have multiple controllers connected at the same time.

In addition, controller management should generally be more robust now. It might be possible that this change also fixes #35, but I wasn't able to test that as I couldn't reproduce the problem.

I believe the same changes can be applied to the Sonic CD decomp repo, but I wanted to see what you think first before making another PR 🙂 

## Changes in detail

* Removed an unnecessary `controllerInit` call in `main.cpp`. This call was not quite correct, because joystick index 0 is not guaranteed to always be a game controller, let alone the one the user is currently holding in their hands. But it is also not necessary, because SDL generates a `SDL_CONTROLLERDEVICEADDED` event for each game controller that's already present during application startup (compare [SDL source](https://github.com/libsdl-org/SDL/blob/a29fe292969157c9262eedf2249b38431d65d00a/src/joystick/SDL_gamecontroller.c#L1639)).
* Use correct ID when calling `controllerInit`/`controllerClose` in response to controllers being added or removed. Previously, this was always using the highest joystick index currently present, but it's not guaranteed that controllers are added or removed in an order matching the order of joystick indices. For example, imagine I plug in controller A and then controller B, but then remove controller A first. The previous code would then incorrectly close controller B. By using the joystick index/instance ID from the event, we make sure to always open or close the controller actually being added or removed.
* Track a list of controllers instead of a single one. Instead of using a single `SDL_GameController*` variable, we now keep a list of them. When controllers are added or removed, we update the list accordingly. In `getControllerButton`, we then check all controllers in the list, and consider a button as pressed if it is currently held down on at least one of the controllers in the list.