### PR TITLE
Fix life subtraction when restarting from pause menu

### DIFF
--- a/Sonic12Decomp/PauseMenu.cpp
+++ b/Sonic12Decomp/PauseMenu.cpp
@@ -123,7 +123,7 @@ void PauseMenu_Main(void *objPtr)
                         stageMode       = STAGEMODE_LOAD;
                         Engine.gameMode = ENGINE_MAINGAME;
                         if (GetGlobalVariableByName("options.gameMode") <= 1) {
-                            SetGlobalVariableByName("options.lives", GetGlobalVariableByName("options.lives") - 1);
+                            SetGlobalVariableByName("player.lives", GetGlobalVariableByName("player.lives") - 1);
                         }
                         SetGlobalVariableByName("lampPostID", 0);
                         SetGlobalVariableByName("starPostID", 0);


### PR DESCRIPTION
The code for subtracting one from the lives value when restarting a stage via the pause menu sets the variable "options.lives" instead of the correct variable "player.lives".