### PR TITLE
Main menu rewrite

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,5 @@
 CXXFLAGS_ALL = $(shell pkg-config --cflags --static sdl2 vorbisfile vorbis glew) $(CXXFLAGS) \
                -DBASE_PATH='"$(BASE_PATH)"' \
-               -DGLEW_STATIC \
                -IRSDKv4/ \
                -IRSDKv4/NativeObjects/ \
                -Idependencies/all/asio/include/ \
@@ -8,7 +7,7 @@ CXXFLAGS_ALL = $(shell pkg-config --cflags --static sdl2 vorbisfile vorbis glew)
                -Idependencies/all/tinyxml2/
 
 LDFLAGS_ALL = $(LDFLAGS)
-LIBS_ALL = $(shell pkg-config --libs --static sdl2 vorbisfile vorbis glew) -lopengl32 -lws2_32 -pthread $(LIBS)
+LIBS_ALL = $(shell pkg-config --libs --static sdl2 vorbisfile vorbis glew) -pthread $(LIBS)
 
 SOURCES = \
           dependencies/all/tinyxml2/tinyxml2.cpp \

--- a/Makefile.msys2
+++ b/Makefile.msys2
@@ -1,0 +1,96 @@
+CXXFLAGS_ALL = $(shell pkg-config --cflags --static sdl2 vorbisfile vorbis glew) $(CXXFLAGS) \
+               -DBASE_PATH='"$(BASE_PATH)"' \
+               -DGLEW_STATIC \
+               -IRSDKv4/ \
+               -IRSDKv4/NativeObjects/ \
+               -Idependencies/all/asio/include/ \
+               -Idependencies/all/stb-image/ \
+               -Idependencies/all/tinyxml2/
+
+LDFLAGS_ALL = $(LDFLAGS)
+LIBS_ALL = $(shell pkg-config --libs --static sdl2 vorbisfile vorbis glew) -lopengl32 -lws2_32 -pthread $(LIBS)
+
+SOURCES = \
+          dependencies/all/tinyxml2/tinyxml2.cpp \
+	  RSDKv4/Animation.cpp     \
+          RSDKv4/Audio.cpp         \
+          RSDKv4/Collision.cpp     \
+          RSDKv4/Debug.cpp         \
+          RSDKv4/Drawing.cpp       \
+          RSDKv4/Ini.cpp           \
+          RSDKv4/Input.cpp         \
+          RSDKv4/main.cpp          \
+          RSDKv4/Math.cpp          \
+	  RSDKv4/ModAPI.cpp        \
+	  RSDKv4/Networking.cpp	   \
+          RSDKv4/Object.cpp        \
+          RSDKv4/Palette.cpp       \
+          RSDKv4/Reader.cpp        \
+          RSDKv4/Renderer.cpp      \
+          RSDKv4/RetroEngine.cpp   \
+          RSDKv4/Scene.cpp         \
+          RSDKv4/Scene3D.cpp       \
+          RSDKv4/Script.cpp        \
+          RSDKv4/Sprite.cpp        \
+          RSDKv4/String.cpp        \
+          RSDKv4/Text.cpp          \
+          RSDKv4/Userdata.cpp      \
+          RSDKv4/NativeObjects/AboutScreen.cpp \
+          RSDKv4/NativeObjects/AchievementDisplay.cpp \
+          RSDKv4/NativeObjects/AchievementsButton.cpp \
+          RSDKv4/NativeObjects/AchievementsMenu.cpp \
+          RSDKv4/NativeObjects/BackButton.cpp \
+          RSDKv4/NativeObjects/CWSplash.cpp \
+          RSDKv4/NativeObjects/CreditText.cpp \
+          RSDKv4/NativeObjects/DialogPanel.cpp \
+          RSDKv4/NativeObjects/FadeScreen.cpp \
+          RSDKv4/NativeObjects/InstructionsScreen.cpp \
+          RSDKv4/NativeObjects/LeaderboardsButton.cpp \
+          RSDKv4/NativeObjects/MenuBG.cpp \
+          RSDKv4/NativeObjects/MenuControl.cpp \
+          RSDKv4/NativeObjects/ModInfoButton.cpp \
+          RSDKv4/NativeObjects/ModsButton.cpp \
+          RSDKv4/NativeObjects/ModsMenu.cpp \
+          RSDKv4/NativeObjects/MultiplayerButton.cpp \
+          RSDKv4/NativeObjects/MultiplayerHandler.cpp \
+          RSDKv4/NativeObjects/MultiplayerScreen.cpp \
+          RSDKv4/NativeObjects/OptionsButton.cpp \
+          RSDKv4/NativeObjects/OptionsMenu.cpp \
+          RSDKv4/NativeObjects/PauseMenu.cpp \
+          RSDKv4/NativeObjects/PlayerSelectScreen.cpp \
+          RSDKv4/NativeObjects/PushButton.cpp \
+          RSDKv4/NativeObjects/RecordsScreen.cpp \
+          RSDKv4/NativeObjects/RetroGameLoop.cpp \
+          RSDKv4/NativeObjects/SaveSelect.cpp \
+          RSDKv4/NativeObjects/SegaIDButton.cpp \
+          RSDKv4/NativeObjects/SegaSplash.cpp \
+          RSDKv4/NativeObjects/SettingsScreen.cpp \
+          RSDKv4/NativeObjects/StaffCredits.cpp \
+          RSDKv4/NativeObjects/StartGameButton.cpp \
+          RSDKv4/NativeObjects/SubMenuButton.cpp \
+          RSDKv4/NativeObjects/TextLabel.cpp \
+          RSDKv4/NativeObjects/TimeAttack.cpp \
+          RSDKv4/NativeObjects/TimeAttackButton.cpp \
+          RSDKv4/NativeObjects/TitleScreen.cpp \
+          RSDKv4/NativeObjects/VirtualDPad.cpp \
+          RSDKv4/NativeObjects/VirtualDPadM.cpp \
+          RSDKv4/NativeObjects/ZoneButton.cpp \
+   
+ifneq ($(FORCE_CASE_INSENSITIVE),)
+	CXXFLAGS_ALL += -DFORCE_CASE_INSENSITIVE
+	SOURCES += RSDKv4/fcaseopen.c
+endif
+
+objects/%.o: %
+	mkdir -p $(@D)
+	$(CXX) $(CXXFLAGS_ALL) -std=c++17 $^ -o $@ -c
+
+bin/RSDKv4: $(SOURCES:%=objects/%.o)
+	mkdir -p $(@D)
+	$(CXX) $(CXXFLAGS_ALL) $(LDFLAGS_ALL) $^ -o $@ $(LIBS_ALL)
+
+install: bin/RSDKv4
+	install -Dp -m755 bin/RSDKv4 $(prefix)/bin/RSDKv4
+
+clean:
+	rm -r -f bin && rm -r -f objects

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ If you want to transfer your save from the **Android pre-forever versions,** you
 * Now install the dependencies with the following command: `pacman -S make git mingw-w64-i686-gcc mingw-w64-x86_64-gcc mingw-w64-x86_64-SDL2 mingw-w64-x86_64-libogg mingw-w64-x86_64-libvorbis mingw-w64-x86_64-glew`
 * Clone the repo with the following command: `git clone https://github.com/Rubberduckycooly/Sonic-1-2-2013-Decompilation.git`
 * Go into the repo you just cloned with `cd Sonic-1-2-2013-Decompilation`
-* Then run `make CXX=x86_64-w64-mingw32-g++ CXXFLAGS=-static -j4` (-j switch is optional but will make building faster, it's based on the number of cores you have +1 so 8 cores wold be -j9)
+* Then run `make -f Makefile.msys2 CXX=x86_64-w64-mingw32-g++ CXXFLAGS=-static -j4` (-j switch is optional but will make building faster, it's based on the number of cores you have +1 so 8 cores wold be -j9)
 
 ## Windows UWP (Phone, Xbox, etc.):
 * Clone the repo, then follow the instructions in the [depencencies readme for Windows](./dependencies/windows/dependencies.txt) and [depencencies readme for UWP](./dependencies/windows-uwp/dependencies.txt) to setup dependencies, copy your `Data.rsdk` folder into `Sonic1Decomp.UWP` or `Sonic2Decomp.UWP` depending on the game, then build and deploy via `Sonic12Decomp.UWP.sln`


### PR DESCRIPTION
So it will be better in that way :
-> Makefile for Windows Visual Studio and Linux
-> Makefile.msys2 for MSYS2 ( tested on Windows 10 x64 )