### PR TITLE
Update to extract the legally obtained APK file

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ![](header.png?raw=true)
 # **SUPPORT THE OFFICIAL RELEASE OF SONIC 1 & SONIC 2**
 + Without assets from the official releases this decompilation will not run.
-+ Video tutorial on how to find your legally obtained Data.rsdk file: https://www.youtube.com/watch?v=gzIfRW91IxE
++ To extract the contents of your legally obtained APK file : download Apktool [here](https://ibotpeaches.github.io/Apktool/) and execute the following command : java -jar apktool_2.6.0.jar d name_of_the_file.apk
 
 + You can get the official release of Sonic 1 & Sonic 2 from:
   * [Sonic 1 (iOS, Via the App Store)](https://apps.apple.com/au/app/sonic-the-hedgehog-classic/id316050001)


### PR DESCRIPTION
Video tutorial is obsolete for now. I tested with a legally 3.6.9 apk file of Sonic 1 and the unzip methods got two errors types : password required and data available after the end of the archive. 

Apktool project created by iBotPeaches (https://github.com/iBotPeaches/Apktool) fixes the extract issues by using the true and good methods to read datas on the APK files. Java is required to use it. Tested with Apktool version 2.6.0 when I wrote these lines