### PR TITLE
Fixed missing <memory> include

### DIFF
--- a/RSDKv4/Networking.hpp
+++ b/RSDKv4/Networking.hpp
@@ -2,6 +2,7 @@
 #ifndef NETWORKING_H
 #define NETWORKING_H
 #include <thread>
+#include <memory>
 
 extern char networkHost[64];
 extern char networkGame[16];


### PR DESCRIPTION
It seems `std::shared_ptr` used to be included implicitly through <thread> in older versions of GCC. Not the case now, so this fix is needed.

Autobuild works because the distribution it uses has an older GCC version, not the case with Arch Linux for example.