### PR TITLE
Remove redundant glu.h inclusion: glew manages this.

### DIFF
--- a/RSDKv4/RetroEngine.hpp
+++ b/RSDKv4/RetroEngine.hpp
@@ -171,7 +171,6 @@ typedef unsigned int uint;
 #define GL_FRAMEBUFFER_BINDING GL_FRAMEBUFFER_BINDING_EXT
 #else
 #include <GL/glew.h>
-#include <GL/glu.h>
 #endif
 #endif
 


### PR DESCRIPTION
By including glew.h, glu.h is included (if needed by glew).
This inclusion is reduntant and breaks building on any modern systems where glew is present but old glu is not.