### PR TITLE
Fix building on GNU/Linux, where libraries are properly installed on the system.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-CXXFLAGS_ALL = $(shell pkg-config --cflags --static sdl2 vorbisfile vorbis glew) $(CXXFLAGS) \
+CXXFLAGS_ALL = $(shell pkg-config --cflags --static sdl2 vorbisfile vorbis glew tinyxml2 stb) $(CXXFLAGS) \
                -DBASE_PATH='"$(BASE_PATH)"' \
                -IRSDKv4/ \
                -IRSDKv4/NativeObjects/ \
@@ -7,10 +7,9 @@ CXXFLAGS_ALL = $(shell pkg-config --cflags --static sdl2 vorbisfile vorbis glew)
                -Idependencies/all/tinyxml2/
 
 LDFLAGS_ALL = $(LDFLAGS)
-LIBS_ALL = $(shell pkg-config --libs --static sdl2 vorbisfile vorbis glew) -pthread $(LIBS)
+LIBS_ALL = $(shell pkg-config --libs --static sdl2 vorbisfile vorbis glew tinyxml2 stb) -pthread $(LIBS)
 
 SOURCES = \
-          dependencies/all/tinyxml2/tinyxml2.cpp \
           RSDKv4/Animation.cpp     \
           RSDKv4/Audio.cpp         \
           RSDKv4/Collision.cpp     \


### PR DESCRIPTION
This fixes building on GNU/Linux, where libraries and their headers are installed on the system and found by pkg-config when they are present.

Same fix was done to SonicCD decomp last month.