### PR TITLE
Improve XDG support on Linux

### DIFF
--- a/RSDKv4/Userdata.cpp
+++ b/RSDKv4/Userdata.cpp
@@ -89,6 +89,8 @@ bool ReadSaveRAMData()
     sprintf(buffer, "%s/%sSData.bin", gamePath, savePath);
 #elif RETRO_PLATFORM == RETRO_iOS
     sprintf(buffer, "%s/%sSData.bin", getDocumentsPath(), savePath);
+#elif RETRO_PLATFORM == RETRO_LINUX
+    sprintf(buffer, "%s/%sSData.bin", getXDGDataPath().c_str(), savePath);
 #else
     sprintf(buffer, "%s%sSData.bin", gamePath, savePath);
 #endif
@@ -121,6 +123,8 @@ bool ReadSaveRAMData()
         sprintf(buffer, "%s/%sSGame.bin", gamePath, savePath);
 #elif RETRO_PLATFORM == RETRO_iOS
         sprintf(buffer, "%s/%sSGame.bin", getDocumentsPath(), savePath);
+#elif RETRO_PLATFORM == RETRO_LINUX
+        sprintf(buffer, "%s/%sSGame.bin", getXDGDataPath().c_str(), savePath);
 #else
         sprintf(buffer, "%s%sSGame.bin", gamePath, savePath);
 #endif
@@ -166,6 +170,8 @@ bool WriteSaveRAMData()
         sprintf(buffer, "%s/%sSData.bin", gamePath, savePath);
 #elif RETRO_PLATFORM == RETRO_iOS
         sprintf(buffer, "%s/%sSData.bin", getDocumentsPath(), savePath);
+#elif RETRO_PLATFORM == RETRO_LINUX
+        sprintf(buffer, "%s/%sSData.bin", getXDGDataPath().c_str(), savePath);
 #else
         sprintf(buffer, "%s%sSData.bin", gamePath, savePath);
 #endif
@@ -197,6 +203,8 @@ bool WriteSaveRAMData()
         sprintf(buffer, "%s/%sSGame.bin", gamePath, savePath);
 #elif RETRO_PLATFORM == RETRO_iOS
         sprintf(buffer, "%s/%sSGame.bin", getDocumentsPath(), savePath);
+#elif RETRO_PLATFORM == RETRO_LINUX
+        sprintf(buffer, "%s/%sSGame.bin", getXDGDataPath().c_str(), savePath);
 #else
         sprintf(buffer, "%s%sSGame.bin", gamePath, savePath);
 #endif
@@ -226,7 +234,7 @@ void InitUserdata()
     mkdir(gamePath, 0777);
 #elif RETRO_PLATFORM == RETRO_LINUX
     sprintf(gamePath, "%s", getXDGDataPath().c_str());
-    sprintf(modsPath, "%s/", getXDGDataPath().c_str());
+    sprintf(modsPath, "%s", getXDGDataPath().c_str());
 
     mkdir(getXDGDataPath().c_str(), 0755);
 #elif RETRO_PLATFORM == RETRO_ANDROID
@@ -861,6 +869,8 @@ void ReadUserdata()
     sprintf(buffer, "%s/%sUData.bin", gamePath, savePath);
 #elif RETRO_PLATFORM == RETRO_iOS
     sprintf(buffer, "%s/%sUData.bin", getDocumentsPath(), savePath);
+#elif RETRO_PLATFORM == RETRO_LINUX
+    sprintf(buffer, "%s/%sUData.bin", getXDGDataPath().c_str(), savePath);
 #else
     sprintf(buffer, "%s%sUData.bin", gamePath, savePath);
 #endif
@@ -916,6 +926,8 @@ void WriteUserdata()
     sprintf(buffer, "%s/%sUData.bin", gamePath, savePath);
 #elif RETRO_PLATFORM == RETRO_iOS
     sprintf(buffer, "%s/%sUData.bin", getDocumentsPath(), savePath);
+#elif RETRO_PLATFORM == RETRO_LINUX
+    sprintf(buffer, "%s/%sUData.bin", getXDGDataPath().c_str(), savePath);
 #else
     sprintf(buffer, "%s%sUData.bin", gamePath, savePath);
 #endif

--- a/flatpak/README.md
+++ b/flatpak/README.md
@@ -3,28 +3,38 @@
 You will need the FreeDesktop.org 21.08 SDK installed, if you don't have it,
 install [Flathub](https://flathub.org/) which provides it.
 
-# Sonic the Hedgehog Flatpak
+# Sonic the Hedgehog
 
-To build and install the Sonic the Hedgehog flatpak you first need the Android
+To build and install the Sonic the Hedgehog flatpak, you first need the Android
 APK for the game. To buy one, visit https://www.sega.com/games/sonic-hedgehog.
 
 Once you have the APK file, rename it to `sonic1.apk` and put it in this
 directory.
 
 To build and install the flatpak, run:
+**System-wide:**
 ```
 $ sudo flatpak-builder --install --force-clean sonic1 com.sega.Sonic1.json
 ```
+**User:**
+```
+$ flatpak-builder --user --install --force-clean sonic1 com.sega.Sonic1.json
+```
 
-# Sonic the Hedgehog 2 Flatpak
+# Sonic the Hedgehog 2
 
-To build and install the Sonic the Hedgehog 2 flatpak you first need the Android
+To build and install the Sonic the Hedgehog 2 flatpak, you first need the Android
 APK for the game. To buy one, visit https://www.sega.com/games/sonic-hedgehog2.
 
 Once you have the APK file, rename it to `sonic2.apk` and put it in this
 directory.
 
 To build and install the flatpak, run:
+**System-wide:**
 ```
 $ sudo flatpak-builder --install --force-clean sonic2 com.sega.Sonic2.json
+```
+**User:**
+```
+$ flatpak-builder --user --install --force-clean sonic2 com.sega.Sonic2.json
 ```


### PR DESCRIPTION
This is a minor fix to XDG support on Linux. 
I noticed while working on CD that there was no XDG support if you didn't use the mod loader, and while I fixed that there, I actually forgot to do the same for 1-2-2013, so there we go.

There are also some minor changes to the flatpak instructions (mostly user install instructions).