### PR TITLE
Flatpak freedesktop sdk update

### DIFF
--- a/flatpak/com.sega.Sonic1.json
+++ b/flatpak/com.sega.Sonic1.json
@@ -1,7 +1,7 @@
 {
     "app-id": "com.sega.Sonic1",
     "runtime": "org.freedesktop.Platform",
-    "runtime-version": "21.08",
+    "runtime-version": "22.08",
     "sdk": "org.freedesktop.Sdk",
     "command": "run.sh",
     "finish-args": [
@@ -35,8 +35,8 @@
             "sources": [
                 {
                     "type": "git",
-                    "url": "https://github.com/Rubberduckycooly/Sonic-1-2-2013-Decompilation.git",
-                    "branch": "main"
+                    "url": "https://github.com/wof8317/Sonic-1-2-2013-Decompilation.git",
+                    "branch": "experiment"
                 },
                 {
                     "type": "file",

--- a/flatpak/com.sega.Sonic1.json
+++ b/flatpak/com.sega.Sonic1.json
@@ -35,8 +35,8 @@
             "sources": [
                 {
                     "type": "git",
-                    "url": "https://github.com/wof8317/Sonic-1-2-2013-Decompilation.git",
-                    "branch": "experiment"
+                    "url": "https://github.com/Rubberduckycooly/Sonic-1-2-2013-Decompilation.git",
+                    "branch": "main"
                 },
                 {
                     "type": "file",

--- a/flatpak/com.sega.Sonic1Origins.json
+++ b/flatpak/com.sega.Sonic1Origins.json
@@ -1,7 +1,7 @@
 {
     "app-id": "com.sega.Sonic1",
     "runtime": "org.freedesktop.Platform",
-    "runtime-version": "21.08",
+    "runtime-version": "22.08",
     "sdk": "org.freedesktop.Sdk",
     "command": "run.sh",
     "finish-args": [

--- a/flatpak/com.sega.Sonic2.json
+++ b/flatpak/com.sega.Sonic2.json
@@ -1,7 +1,7 @@
 {
     "app-id": "com.sega.Sonic2",
     "runtime": "org.freedesktop.Platform",
-    "runtime-version": "21.08",
+    "runtime-version": "22.08",
     "sdk": "org.freedesktop.Sdk",
     "command": "run.sh",
     "finish-args": [

--- a/flatpak/com.sega.Sonic2Origins.json
+++ b/flatpak/com.sega.Sonic2Origins.json
@@ -1,7 +1,7 @@
 {
     "app-id": "com.sega.Sonic2",
     "runtime": "org.freedesktop.Platform",
-    "runtime-version": "21.08",
+    "runtime-version": "22.08",
     "sdk": "org.freedesktop.Sdk",
     "command": "run.sh",
     "finish-args": [


### PR DESCRIPTION
Update flatpak scripts to use the latest freedesktop Platform Sdk (22.08).