### PR TITLE
Add support for SDL3, among other changes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-CXXFLAGS_ALL = $(shell pkg-config --cflags --static sdl3 vorbisfile vorbis glew) $(CXXFLAGS) \
+CXXFLAGS_ALL = $(shell pkg-config --cflags --static sdl2 vorbisfile vorbis glew) $(CXXFLAGS) \
                -DBASE_PATH='"$(BASE_PATH)"' \
                -IRSDKv4/ \
                -IRSDKv4/NativeObjects/ \
@@ -7,7 +7,7 @@ CXXFLAGS_ALL = $(shell pkg-config --cflags --static sdl3 vorbisfile vorbis glew)
                -Idependencies/all/tinyxml2/
 
 LDFLAGS_ALL = $(LDFLAGS)
-LIBS_ALL = $(shell pkg-config --libs --static sdl3 vorbisfile vorbis glew) -pthread $(LIBS)
+LIBS_ALL = $(shell pkg-config --libs --static sdl2 vorbisfile vorbis glew) -pthread $(LIBS)
 
 SOURCES = dependencies/all/tinyxml2/tinyxml2.cpp \
           RSDKv4/Animation.cpp     \

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-CXXFLAGS_ALL = $(shell pkg-config --cflags --static sdl2 vorbisfile vorbis glew) $(CXXFLAGS) \
+CXXFLAGS_ALL = $(shell pkg-config --cflags --static sdl3 vorbisfile vorbis glew) $(CXXFLAGS) \
                -DBASE_PATH='"$(BASE_PATH)"' \
                -IRSDKv4/ \
                -IRSDKv4/NativeObjects/ \
@@ -7,7 +7,7 @@ CXXFLAGS_ALL = $(shell pkg-config --cflags --static sdl2 vorbisfile vorbis glew)
                -Idependencies/all/tinyxml2/
 
 LDFLAGS_ALL = $(LDFLAGS)
-LIBS_ALL = $(shell pkg-config --libs --static sdl2 vorbisfile vorbis glew) -pthread $(LIBS)
+LIBS_ALL = $(shell pkg-config --libs --static sdl3 vorbisfile vorbis glew) -pthread $(LIBS)
 
 SOURCES = dependencies/all/tinyxml2/tinyxml2.cpp \
           RSDKv4/Animation.cpp     \

--- a/RSDKv4/Audio.cpp
+++ b/RSDKv4/Audio.cpp
@@ -29,9 +29,9 @@ ChannelInfo sfxChannels[CHANNEL_COUNT];
 
 int currentMusicTrack = -1;
 
-#if RETRO_USING_SDL1 || RETRO_USING_SDL2
+#if RETRO_USING_SDL1 || RETRO_USING_SDL2 || RETRO_USING_SDL3
 
-#if RETRO_USING_SDL2
+#if RETRO_USING_SDL2 || RETRO_USING_SDL3
 SDL_AudioDeviceID audioDevice;
 #endif
 SDL_AudioSpec audioDeviceFormat;
@@ -49,7 +49,7 @@ int InitAudioPlayback()
     StopAllSfx(); //"init"
 
 #if !RETRO_USE_ORIGINAL_CODE
-#if RETRO_USING_SDL1 || RETRO_USING_SDL2
+#if RETRO_USING_SDL1 || RETRO_USING_SDL2 || RETRO_USING_SDL3
     SDL_AudioSpec want;
     want.freq     = AUDIO_FREQUENCY;
     want.format   = AUDIO_FORMAT;
@@ -57,7 +57,18 @@ int InitAudioPlayback()
     want.channels = AUDIO_CHANNELS;
     want.callback = ProcessAudioPlayback;
 
-#if RETRO_USING_SDL2
+#if RETRO_USING_SDL3
+    if ((audioDevice = SDL_OpenAudioDevice(nullptr, 0, &want, &audioDeviceFormat, SDL_AUDIO_ALLOW_FREQUENCY_CHANGE)) > 0) {
+        audioEnabled = true;
+        SDL_PauseAudioDevice(audioDevice, 0);
+    }
+    else {
+        PrintLog("Unable to open audio device: %s", SDL_GetError());
+        audioEnabled = false;
+        return true;
+    }
+
+#elif RETRO_USING_SDL2
     if ((audioDevice = SDL_OpenAudioDevice(nullptr, 0, &want, &audioDeviceFormat, SDL_AUDIO_ALLOW_FREQUENCY_CHANGE)) > 0) {
         audioEnabled = true;
         SDL_PauseAudioDevice(audioDevice, 0);
@@ -208,6 +219,38 @@ void ProcessMusicStream(Sint32 *stream, size_t bytes_wanted)
     switch (musicStatus) {
         case MUSIC_READY:
         case MUSIC_PLAYING: {
+#if RETRO_USING_SDL3
+            while (musicStatus == MUSIC_PLAYING && streamInfoPtr->stream && SDL_AudioStreamAvailable(streamInfoPtr->stream) < bytes_wanted) {
+                // We need more samples: get some
+                long bytes_read = ov_read(&streamInfoPtr->vorbisFile, (char *)streamInfoPtr->buffer, sizeof(streamInfoPtr->buffer), 0, 2, 1,
+                                          &streamInfoPtr->vorbBitstream);
+
+                if (bytes_read == 0) {
+                    // We've reached the end of the file
+                    if (streamInfoPtr->trackLoop) {
+                        ov_pcm_seek(&streamInfoPtr->vorbisFile, streamInfoPtr->loopPoint);
+                        continue;
+                    }
+                    else {
+                        musicStatus = MUSIC_STOPPED;
+                        break;
+                    }
+                }
+
+                if (musicStatus != MUSIC_PLAYING
+                    || (streamInfoPtr->stream && SDL_AudioStreamPut(streamInfoPtr->stream, streamInfoPtr->buffer, (int)bytes_read) == -1))
+                    return;
+            }
+
+            // Now that we know there are enough samples, read them and mix them
+            int bytes_done = SDL_AudioStreamGet(streamInfoPtr->stream, streamInfoPtr->buffer, (int)bytes_wanted);
+            if (bytes_done == -1) {
+                return;
+            }
+            if (bytes_done != 0)
+                ProcessAudioMixing(stream, streamInfoPtr->buffer, bytes_done / sizeof(Sint16), (bgmVolume * masterVolume) / MAX_VOLUME, 0);
+#endif
+
 #if RETRO_USING_SDL2
             while (musicStatus == MUSIC_PLAYING && streamInfoPtr->stream && SDL_AudioStreamAvailable(streamInfoPtr->stream) < bytes_wanted) {
                 // We need more samples: get some
@@ -367,7 +410,7 @@ void ProcessAudioPlayback(void *userdata, Uint8 *stream, int len)
                     }
                 }
 
-#if RETRO_USING_SDL1 || RETRO_USING_SDL2
+#if RETRO_USING_SDL1 || RETRO_USING_SDL2 || RETRO_USING_SDL3
                 ProcessAudioMixing(mix_buffer, buffer, (int)samples_done, sfxVolume, sfx->pan);
 #endif
             }
@@ -392,7 +435,7 @@ void ProcessAudioPlayback(void *userdata, Uint8 *stream, int len)
     }
 }
 
-#if RETRO_USING_SDL1 || RETRO_USING_SDL2
+#if RETRO_USING_SDL1 || RETRO_USING_SDL2 || RETRO_USING_SDL3
 void ProcessAudioMixing(Sint32 *dst, const Sint16 *src, int len, int volume, sbyte pan)
 {
     if (volume == 0)
@@ -474,7 +517,7 @@ void LoadMusic(void *userdata)
 
             samples = (unsigned long long)ov_pcm_total(&strmInfo->vorbisFile, -1);
 
-#if RETRO_USING_SDL2
+#if RETRO_USING_SDL2 || RETRO_USING_SDL3
             strmInfo->stream = SDL_NewAudioStream(AUDIO_S16, strmInfo->vorbisFile.vi->channels, (int)strmInfo->vorbisFile.vi->rate,
                                                   audioDeviceFormat.format, audioDeviceFormat.channels, audioDeviceFormat.freq);
             if (!strmInfo->stream)

--- a/RSDKv4/Audio.hpp
+++ b/RSDKv4/Audio.hpp
@@ -16,7 +16,7 @@
 
 #define MIX_BUFFER_SAMPLES (256)
 
-#if RETRO_USING_SDL1 || RETRO_USING_SDL2
+#if RETRO_USING_SDL1 || RETRO_USING_SDL2 || RETRO_USING_SDL3
 
 #define LockAudioDevice()   SDL_LockAudio()
 #define UnlockAudioDevice() SDL_UnlockAudio()
@@ -38,7 +38,7 @@ struct StreamInfo {
 #if RETRO_USING_SDL1
     SDL_AudioSpec spec;
 #endif
-#if RETRO_USING_SDL2
+#if RETRO_USING_SDL2 || RETRO_USING_SDL3
     SDL_AudioStream *stream;
 #endif
     Sint16 buffer[MIX_BUFFER_SAMPLES];
@@ -103,14 +103,14 @@ extern char sfxNames[SFX_COUNT][0x40];
 
 extern ChannelInfo sfxChannels[CHANNEL_COUNT];
 
-#if RETRO_USING_SDL1 || RETRO_USING_SDL2
+#if RETRO_USING_SDL1 || RETRO_USING_SDL2 || RETRO_USING_SDL3
 extern SDL_AudioSpec audioDeviceFormat;
 #endif
 
 int InitAudioPlayback();
 void LoadGlobalSfx();
 
-#if RETRO_USING_SDL1 || RETRO_USING_SDL2
+#if RETRO_USING_SDL1 || RETRO_USING_SDL2 || RETRO_USING_SDL3
 #if !RETRO_USE_ORIGINAL_CODE
 // These functions did exist, but with different signatures
 void ProcessMusicStream(Sint32 *stream, size_t bytes_wanted);
@@ -123,7 +123,7 @@ inline void freeMusInfo()
 {
     LockAudioDevice();
 
-#if RETRO_USING_SDL2
+#if RETRO_USING_SDL2 || RETRO_USING_SDL3
     if (streamInfo[currentStreamIndex].stream)
         SDL_FreeAudioStream(streamInfo[currentStreamIndex].stream);
     streamInfo[currentStreamIndex].stream = NULL;
@@ -131,7 +131,7 @@ inline void freeMusInfo()
 
     ov_clear(&streamInfo[currentStreamIndex].vorbisFile);
 
-#if RETRO_USING_SDL2
+#if RETRO_USING_SDL2 || RETRO_USING_SDL3
     streamInfo[currentStreamIndex].stream = nullptr;
 #endif
 

--- a/RSDKv4/Drawing.cpp
+++ b/RSDKv4/Drawing.cpp
@@ -57,7 +57,7 @@ int InitRenderDevice()
     sprintf(gameTitle, "%s%s", Engine.gameWindowText, Engine.usingDataFile_Config ? "" : " (Using Data Folder)");
 
 #if !RETRO_USE_ORIGINAL_CODE
-#if RETRO_USING_SDL2
+#if RETRO_USING_SDL2 || RETRO_USING_SDL3
     SDL_Init(SDL_INIT_EVERYTHING);
 
     SDL_DisableScreenSaver();
@@ -317,7 +317,7 @@ void FlipScreen()
     }
 
 #if RETRO_SOFTWARE_RENDER && !RETRO_USING_OPENGL
-#if RETRO_USING_SDL2
+#if RETRO_USING_SDL2 || RETRO_USING_SDL3
     SDL_Rect destScreenPos_scaled;
     SDL_Texture *texTarget = NULL;
 
@@ -528,7 +528,7 @@ void ReleaseRenderDevice()
         delete[] Engine.frameBuffer;
     if (Engine.frameBuffer2x)
         delete[] Engine.frameBuffer2x;
-#if RETRO_USING_SDL2 && !RETRO_USING_OPENGL
+#if (RETRO_USING_SDL2 || RETRO_USING_SDL3) && !RETRO_USING_OPENGL
     SDL_DestroyTexture(Engine.screenBuffer);
     Engine.screenBuffer = NULL;
 #endif
@@ -545,7 +545,7 @@ void ReleaseRenderDevice()
         SDL_GL_DeleteContext(Engine.glContext);
 #endif
 
-#if RETRO_USING_SDL2
+#if RETRO_USING_SDL2 || RETRO_USING_SDL3
 #if !RETRO_USING_OPENGL
     SDL_DestroyRenderer(Engine.renderer);
 #endif
@@ -929,7 +929,7 @@ void SetFullScreen(bool fs)
         Engine.windowSurface =
             SDL_SetVideoMode(SCREEN_XSIZE * Engine.windowScale, SCREEN_YSIZE * Engine.windowScale, 16, SDL_SWSURFACE | SDL_FULLSCREEN);
         SDL_ShowCursor(SDL_FALSE);
-#elif RETRO_USING_SDL2
+#elif RETRO_USING_SDL2 || RETRO_USING_SDL3
         SDL_RestoreWindow(Engine.window);
         SDL_SetWindowFullscreen(Engine.window, SDL_WINDOW_FULLSCREEN_DESKTOP);
         SDL_ShowCursor(SDL_FALSE);
@@ -968,7 +968,7 @@ void SetFullScreen(bool fs)
 #if RETRO_USING_SDL1
         Engine.windowSurface = SDL_SetVideoMode(SCREEN_XSIZE * Engine.windowScale, SCREEN_YSIZE * Engine.windowScale, 16, SDL_SWSURFACE);
         SDL_ShowCursor(SDL_TRUE);
-#elif RETRO_USING_SDL2
+#elif RETRO_USING_SDL2 || RETRO_USING_SDL3
         SDL_SetWindowFullscreen(Engine.window, false);
         SDL_ShowCursor(SDL_TRUE);
         SDL_SetWindowSize(Engine.window, SCREEN_XSIZE_CONFIG * Engine.windowScale, SCREEN_YSIZE * Engine.windowScale);

--- a/RSDKv4/Input.cpp
+++ b/RSDKv4/Input.cpp
@@ -31,7 +31,7 @@ int lastMouseX     = 0;
 int lastMouseY     = 0;
 
 struct InputDevice {
-#if RETRO_USING_SDL2
+#if RETRO_USING_SDL2 || RETRO_USING_SDL3
     SDL_GameController *devicePtr;
     SDL_Haptic *hapticPtr;
 #endif
@@ -49,7 +49,7 @@ byte keyState[SDLK_LAST];
 
 #define normalize(val, minVal, maxVal) ((float)(val) - (float)(minVal)) / ((float)(maxVal) - (float)(minVal))
 
-#if RETRO_USING_SDL2
+#if RETRO_USING_SDL2 || RETRO_USING_SDL3
 bool getControllerButton(byte buttonID)
 {
     bool pressed = false;
@@ -204,7 +204,7 @@ bool getControllerButton(byte buttonID)
 
     return pressed;
 }
-#endif //! RETRO_USING_SDL2
+#endif //! RETRO_USING_SDL2 or RETRO_USING_SDL3
 
 void controllerInit(byte controllerID)
 {
@@ -214,7 +214,7 @@ void controllerInit(byte controllerID)
         }
     }
 
-#if RETRO_USING_SDL2
+#if RETRO_USING_SDL2 || RETRO_USING_SDL3
     SDL_GameController *controller = SDL_GameControllerOpen(controllerID);
     if (controller) {
         InputDevice device;
@@ -241,7 +241,7 @@ void controllerInit(byte controllerID)
 
 void controllerClose(byte controllerID)
 {
-#if RETRO_USING_SDL2
+#if RETRO_USING_SDL2 || RETRO_USING_SDL3
     SDL_GameController *controller = SDL_GameControllerFromInstanceID(controllerID);
     if (controller) {
         SDL_GameControllerClose(controller);
@@ -249,7 +249,7 @@ void controllerClose(byte controllerID)
         for (int i = 0; i < controllers.size(); ++i) {
             if (controllers[i].id == controllerID) {
                 controllers.erase(controllers.begin() + controllerID);
-#if RETRO_USING_SDL2
+#if RETRO_USING_SDL2 || RETRO_USING_SDL3
                 if (controllers[i].hapticPtr) {
                     SDL_HapticClose(controllers[i].hapticPtr);
                 }
@@ -257,7 +257,7 @@ void controllerClose(byte controllerID)
                 break;
             }
         }
-#if RETRO_USING_SDL2
+#if RETRO_USING_SDL2 || RETRO_USING_SDL3
     }
 #endif
 
@@ -267,7 +267,7 @@ void controllerClose(byte controllerID)
 
 void InitInputDevices()
 {
-#if RETRO_USING_SDL2
+#if RETRO_USING_SDL2 || RETRO_USING_SDL3
     PrintLog("Initializing gamepads...");
 
     // fix for issue #334 on github, not sure what's going wrong, but it seems to not be initializing the gamepad api maybe?
@@ -303,7 +303,7 @@ void InitInputDevices()
 void ReleaseInputDevices()
 {
     for (int i = 0; i < controllers.size(); i++) {
-#if RETRO_USING_SDL2
+#if RETRO_USING_SDL2 || RETRO_USING_SDL3
         if (controllers[i].devicePtr)
             SDL_GameControllerClose(controllers[i].devicePtr);
         if (controllers[i].hapticPtr)
@@ -315,7 +315,7 @@ void ReleaseInputDevices()
 
 void ProcessInput()
 {
-#if RETRO_USING_SDL2
+#if RETRO_USING_SDL2 || RETRO_USING_SDL3
     int length           = 0;
     const byte *keyState = SDL_GetKeyboardState(&length);
 

--- a/RSDKv4/Input.hpp
+++ b/RSDKv4/Input.hpp
@@ -88,7 +88,7 @@ extern int lastMouseY;
 #endif
 
 #if !RETRO_USE_ORIGINAL_CODE
-#if RETRO_USING_SDL2
+#if RETRO_USING_SDL2 || RETRO_USING_SDL3
 // Easier this way
 enum ExtraSDLButtons {
     SDL_CONTROLLER_BUTTON_ZL = SDL_CONTROLLER_BUTTON_MAX + 1,

--- a/RSDKv4/ModAPI.cpp
+++ b/RSDKv4/ModAPI.cpp
@@ -413,7 +413,7 @@ void RefreshEngine()
 {
     // Reload entire engine
     Engine.LoadGameConfig("Data/Game/GameConfig.bin");
-#if RETRO_USING_SDL2
+#if RETRO_USING_SDL2 || RETRO_USING_SDL3
     if (Engine.window) {
         char gameTitle[0x40];
         sprintf(gameTitle, "%s%s", Engine.gameWindowText, Engine.usingDataFile_Config ? "" : " (Using Data Folder)");

--- a/RSDKv4/Reader.hpp
+++ b/RSDKv4/Reader.hpp
@@ -14,7 +14,7 @@
 
 #else
 
-#if RETRO_USING_SDL1 || RETRO_USING_SDL2
+#if RETRO_USING_SDL1 || RETRO_USING_SDL2 || RETRO_USING_SDL3
 #define FileIO                                          SDL_RWops
 #define fOpen(path, mode)                               SDL_RWFromFile(path, mode)
 #define fRead(buffer, elementSize, elementCount, file)  SDL_RWread(file, buffer, elementSize, elementCount)

--- a/RSDKv4/RetroEngine.cpp
+++ b/RSDKv4/RetroEngine.cpp
@@ -32,11 +32,11 @@ inline int getLowerRate(int intendRate, int targetRate)
 bool processEvents()
 {
 #if !RETRO_USE_ORIGINAL_CODE
-#if RETRO_USING_SDL1 || RETRO_USING_SDL2
+#if RETRO_USING_SDL1 || RETRO_USING_SDL2 || RETRO_USING_SDL3
     while (SDL_PollEvent(&Engine.sdlEvents)) {
         // Main Events
         switch (Engine.sdlEvents.type) {
-#if RETRO_USING_SDL2
+#if RETRO_USING_SDL2 || RETRO_USING_SDL3
             case SDL_WINDOWEVENT:
                 switch (Engine.sdlEvents.window.event) {
                     case SDL_WINDOWEVENT_MAXIMIZED: {
@@ -74,7 +74,7 @@ bool processEvents()
             case SDL_APP_TERMINATING: return false;
 #endif
 
-#if RETRO_USING_SDL2 && defined(RETRO_USING_MOUSE)
+#if (RETRO_USING_SDL2 || RETRO_USING_SDL3) && defined(RETRO_USING_MOUSE)
             case SDL_MOUSEMOTION:
                 if (touches <= 1) { // Touch always takes priority over mouse
                     uint state = SDL_GetMouseState(&touchX[0], &touchY[0]);
@@ -107,7 +107,7 @@ bool processEvents()
                 break;
 #endif
 
-#if defined(RETRO_USING_TOUCH) && RETRO_USING_SDL2
+#if defined(RETRO_USING_TOUCH) && (RETRO_USING_SDL2 || RETRO_USING_SDL3)
             case SDL_FINGERMOTION:
             case SDL_FINGERDOWN:
             case SDL_FINGERUP: {
@@ -537,7 +537,7 @@ void RetroEngine::Run()
                 FlipScreen();
 
 #if !RETRO_USE_ORIGINAL_CODE
-#if RETRO_USING_OPENGL && RETRO_USING_SDL2
+#if RETRO_USING_OPENGL && (RETRO_USING_SDL2 || RETRO_USING_SDL3)
                 SDL_GL_SwapWindow(Engine.window);
 #endif
                 frameStep = false;
@@ -573,7 +573,7 @@ void RetroEngine::Run()
 #endif
 #endif
 
-#if RETRO_USING_SDL1 || RETRO_USING_SDL2
+#if RETRO_USING_SDL1 || RETRO_USING_SDL2 || RETRO_USING_SDL3
     SDL_Quit();
 #endif
 }

--- a/RSDKv4/RetroEngine.hpp
+++ b/RSDKv4/RetroEngine.hpp
@@ -93,10 +93,12 @@ typedef unsigned int uint;
 #if RETRO_PLATFORM == RETRO_WIN || RETRO_PLATFORM == RETRO_OSX || RETRO_PLATFORM == RETRO_LINUX || RETRO_PLATFORM == RETRO_UWP                       \
     || RETRO_PLATFORM == RETRO_ANDROID
 #define RETRO_USING_SDL1 (0)
-#define RETRO_USING_SDL2 (1)
+#define RETRO_USING_SDL2 (0)
+#define RETRO_USING_SDL3 (1) // Experimental
 #else // Since its an else & not an elif these platforms probably aren't supported yet
 #define RETRO_USING_SDL1 (0)
 #define RETRO_USING_SDL2 (0)
+#define RETRO_USING_SDL3 (0)
 #endif
 
 #if RETRO_PLATFORM == RETRO_iOS || RETRO_PLATFORM == RETRO_ANDROID || RETRO_PLATFORM == RETRO_WP7
@@ -276,6 +278,8 @@ enum RetroGameType {
 #include <SDL.h>
 #elif RETRO_USING_SDL1
 #include <SDL.h>
+#elif RETRO_USING_SDL3
+#include <SDL3/SDL.h>
 #endif
 #include <vorbis/vorbisfile.h>
 #elif RETRO_PLATFORM == RETRO_OSX
@@ -286,6 +290,10 @@ enum RetroGameType {
 
 #elif RETRO_USING_SDL2
 #include <SDL2/SDL.h>
+#include <vorbis/vorbisfile.h>
+
+#elif RETRO_USING_SDL3
+#include <SDL3/SDL.h>
 #include <vorbis/vorbisfile.h>
 #else
 
@@ -465,7 +473,7 @@ public:
 #endif
 
 #if !RETRO_USE_ORIGINAL_CODE
-#if RETRO_USING_SDL2
+#if RETRO_USING_SDL2 || RETRO_USING_SDL3
     SDL_Window *window = nullptr;
 #if !RETRO_USING_OPENGL
     SDL_Renderer *renderer = nullptr;

--- a/RSDKv4/RetroEngine.hpp
+++ b/RSDKv4/RetroEngine.hpp
@@ -93,8 +93,8 @@ typedef unsigned int uint;
 #if RETRO_PLATFORM == RETRO_WIN || RETRO_PLATFORM == RETRO_OSX || RETRO_PLATFORM == RETRO_LINUX || RETRO_PLATFORM == RETRO_UWP                       \
     || RETRO_PLATFORM == RETRO_ANDROID
 #define RETRO_USING_SDL1 (0)
-#define RETRO_USING_SDL2 (0)
-#define RETRO_USING_SDL3 (1) // Experimental
+#define RETRO_USING_SDL2 (1)
+#define RETRO_USING_SDL3 (0) // Initial SDL3 support, probably not ready for use until SDL3 officially releases.
 #else // Since its an else & not an elif these platforms probably aren't supported yet
 #define RETRO_USING_SDL1 (0)
 #define RETRO_USING_SDL2 (0)
@@ -279,7 +279,7 @@ enum RetroGameType {
 #elif RETRO_USING_SDL1
 #include <SDL.h>
 #elif RETRO_USING_SDL3
-#include <SDL3/SDL.h>
+#include <SDL.h>
 #endif
 #include <vorbis/vorbisfile.h>
 #elif RETRO_PLATFORM == RETRO_OSX

--- a/RSDKv4/Userdata.cpp
+++ b/RSDKv4/Userdata.cpp
@@ -289,7 +289,7 @@ void InitUserdata()
         ini.SetFloat("Audio", "BGMVolume", bgmVolume / (float)MAX_VOLUME);
         ini.SetFloat("Audio", "SFXVolume", sfxVolume / (float)MAX_VOLUME);
 
-#if RETRO_USING_SDL2
+#if RETRO_USING_SDL2 || RETRO_USING_SDL3
         ini.SetInteger("Keyboard 1", "Up", inputDevice[INPUT_UP].keyMappings = SDL_SCANCODE_UP);
         ini.SetInteger("Keyboard 1", "Down", inputDevice[INPUT_DOWN].keyMappings = SDL_SCANCODE_DOWN);
         ini.SetInteger("Keyboard 1", "Left", inputDevice[INPUT_LEFT].keyMappings = SDL_SCANCODE_LEFT);
@@ -462,7 +462,7 @@ void InitUserdata()
         if (sfxVolume < 0)
             sfxVolume = 0;
 
-#if RETRO_USING_SDL2
+#if RETRO_USING_SDL2 || RETRO_USING_SDL3
         if (!ini.GetInteger("Keyboard 1", "Up", &inputDevice[INPUT_UP].keyMappings))
             inputDevice[INPUT_UP].keyMappings = SDL_SCANCODE_UP;
         if (!ini.GetInteger("Keyboard 1", "Down", &inputDevice[INPUT_DOWN].keyMappings))
@@ -601,7 +601,7 @@ void InitUserdata()
 #endif
     }
 
-#if RETRO_USING_SDL2
+#if RETRO_USING_SDL2 || RETRO_USING_SDL3
     // Support for extra controller types SDL doesn't recognise
 #if RETRO_PLATFORM == RETRO_UWP
     if (!usingCWD)
@@ -722,7 +722,7 @@ void WriteSettings()
     ini.SetFloat("Audio", "BGMVolume", bgmVolume / (float)MAX_VOLUME);
     ini.SetFloat("Audio", "SFXVolume", sfxVolume / (float)MAX_VOLUME);
 
-#if RETRO_USING_SDL2
+#if RETRO_USING_SDL2 || RETRO_USING_SDL3
     ini.SetComment("Keyboard 1", "IK1Comment",
                    "Keyboard Mappings for P1 (Based on: https://github.com/libsdl-org/sdlwiki/blob/main/SDLScancodeLookup.mediawiki)");
 #endif
@@ -744,7 +744,7 @@ void WriteSettings()
     ini.SetInteger("Keyboard 1", "Start", inputDevice[INPUT_START].keyMappings);
     ini.SetInteger("Keyboard 1", "Select", inputDevice[INPUT_SELECT].keyMappings);
 
-#if RETRO_USING_SDL2
+#if RETRO_USING_SDL2 || RETRO_USING_SDL3
     ini.SetComment("Controller 1", "IC1Comment",
                    "Controller Mappings for P1 (Based on: https://github.com/libsdl-org/sdlwiki/blob/main/SDL_GameControllerButton.mediawiki)");
     ini.SetComment("Controller 1", "IC1Comment2", "Extra buttons can be mapped with the following IDs:");
@@ -1279,7 +1279,7 @@ void SetScreenWidth(int *width, int *unused)
 #if RETRO_PLATFORM != RETRO_ANDROID
     SetScreenDimensions(SCREEN_XSIZE_CONFIG * Engine.windowScale, SCREEN_YSIZE * Engine.windowScale);
 #endif
-#if RETRO_USING_SDL2
+#if RETRO_USING_SDL2 || RETRO_USING_SDL3
     InitRenderDevice();
 #endif
 
@@ -1294,7 +1294,7 @@ void SetScreenWidth(int *width, int *unused)
 void SetWindowScale(int *scale, int *unused)
 {
     Engine.windowScale = *scale;
-#if RETRO_USING_SDL2
+#if RETRO_USING_SDL2 || RETRO_USING_SDL3
     SDL_SetWindowSize(Engine.window, SCREEN_XSIZE_CONFIG * Engine.windowScale, SCREEN_YSIZE * Engine.windowScale);
 #endif
 
@@ -1316,7 +1316,7 @@ void SetWindowFullScreen(int *fullscreen, int *unused)
 void SetWindowBorderless(int *borderless, int *unused)
 {
     Engine.borderless = *borderless;
-#if RETRO_USING_SDL2
+#if RETRO_USING_SDL2 || RETRO_USING_SDL3
     SDL_RestoreWindow(Engine.window);
     SDL_SetWindowBordered(Engine.window, Engine.borderless ? SDL_FALSE : SDL_TRUE);
 #endif

--- a/flatpak/com.sega.Sonic1.json
+++ b/flatpak/com.sega.Sonic1.json
@@ -1,7 +1,7 @@
 {
     "app-id": "com.sega.Sonic1",
     "runtime": "org.freedesktop.Platform",
-    "runtime-version": "21.08",
+    "runtime-version": "22.08",
     "sdk": "org.freedesktop.Sdk",
     "command": "run.sh",
     "finish-args": [
@@ -35,8 +35,8 @@
             "sources": [
                 {
                     "type": "git",
-                    "url": "https://github.com/Rubberduckycooly/Sonic-1-2-2013-Decompilation.git",
-                    "branch": "main"
+                    "url": "https://github.com/wof8317/Sonic-1-2-2013-Decompilation.git",
+                    "branch": "experiment"
                 },
                 {
                     "type": "file",

--- a/flatpak/com.sega.Sonic1.json
+++ b/flatpak/com.sega.Sonic1.json
@@ -35,8 +35,8 @@
             "sources": [
                 {
                     "type": "git",
-                    "url": "https://github.com/wof8317/Sonic-1-2-2013-Decompilation.git",
-                    "branch": "experiment"
+                    "url": "https://github.com/Rubberduckycooly/Sonic-1-2-2013-Decompilation.git",
+                    "branch": "main"
                 },
                 {
                     "type": "file",

--- a/flatpak/com.sega.Sonic1Origins.json
+++ b/flatpak/com.sega.Sonic1Origins.json
@@ -1,7 +1,7 @@
 {
     "app-id": "com.sega.Sonic1",
     "runtime": "org.freedesktop.Platform",
-    "runtime-version": "21.08",
+    "runtime-version": "22.08",
     "sdk": "org.freedesktop.Sdk",
     "command": "run.sh",
     "finish-args": [

--- a/flatpak/com.sega.Sonic2.json
+++ b/flatpak/com.sega.Sonic2.json
@@ -1,7 +1,7 @@
 {
     "app-id": "com.sega.Sonic2",
     "runtime": "org.freedesktop.Platform",
-    "runtime-version": "21.08",
+    "runtime-version": "22.08",
     "sdk": "org.freedesktop.Sdk",
     "command": "run.sh",
     "finish-args": [

--- a/flatpak/com.sega.Sonic2Origins.json
+++ b/flatpak/com.sega.Sonic2Origins.json
@@ -1,7 +1,7 @@
 {
     "app-id": "com.sega.Sonic2",
     "runtime": "org.freedesktop.Platform",
-    "runtime-version": "21.08",
+    "runtime-version": "22.08",
     "sdk": "org.freedesktop.Sdk",
     "command": "run.sh",
     "finish-args": [


### PR DESCRIPTION
I added initial support for the upcoming SDL3. By default, it still compiles using SDL2 to prevent any problems (Basically, I added a "RETRO_USING_SDL3" define. This may need to change when SDL3 is officially released (i.e. set RETRO_USING_SDL3 to 1 and change the makefile to sdl3 instead of sdl2, but that won't be for a while). Also, for the Flatpak scripts, I changed the freedesktop SDK version to the latest version "22.08". 