### PR TITLE
Fix built-in alias counts

### DIFF
--- a/RSDKv4/Script.cpp
+++ b/RSDKv4/Script.cpp
@@ -2,20 +2,11 @@
 #include <cmath>
 
 #if RETRO_USE_COMPILER
-#if RETRO_USE_ORIGINAL_CODE
 
 #if !RETRO_REV00
 #define COMMON_SCRIPT_VAR_COUNT (34)
 #else
 #define COMMON_SCRIPT_VAR_COUNT (33)
-#endif
-
-#else
-
-#if !RETRO_REV00
-#define COMMON_SCRIPT_VAR_COUNT (110)
-#else
-#define COMMON_SCRIPT_VAR_COUNT (109)
 #endif
 
 #endif


### PR DESCRIPTION
One of the recent commits (d3e011d326090fa30a54ab31f604369bba94b9b9) removed the custom decomp aliases from the script compiler, it didn't change the according aliases for it at the top of the file though so this PR does so.