### PR TITLE
Minor note fix

### DIFF
--- a/RSDKv4/Collision.cpp
+++ b/RSDKv4/Collision.cpp
@@ -2602,7 +2602,7 @@ void BoxCollision2(Entity *thisEntity, int thisLeft, int thisTop, int thisRight,
         sensors[0].ypos = ry + otherBottom;
 
         if (otherEntity->yvel >= 0) {
-            // this should prolly be using all 5 sensors, but this was unused in S2 so it was prolly forgotten about
+            // this should prolly be using all 5 sensors, but this was barely used in S2 so it was prolly forgotten about
             for (int i = 0; i < 3; ++i) {
                 if (thisLeft < sensors[i].xpos && thisRight > sensors[i].xpos && thisTop <= sensors[0].ypos && thisEntity->ypos > sensors[0].ypos) {
                     sensors[i].collided          = true;


### PR DESCRIPTION
One of the comments in Collision.cpp labels the Box2/Solid2 collision type as unused in Sonic 2, even though it is actually used a few times. This little PR rectifies that.