### PR TITLE
Fixed: Mods don't work if parent dir ends in Data

### DIFF
--- a/RSDKv4/ModAPI.cpp
+++ b/RSDKv4/ModAPI.cpp
@@ -262,7 +262,7 @@ void ScanModFolder(ModInfo *info)
                     };
                     int tokenPos = -1;
                     for (int i = 0; i < 4; ++i) {
-                        tokenPos = FindStringToken(modBuf, folderTest[i], 1);
+                        tokenPos = FindLastStringToken(modBuf, folderTest[i]);
                         if (tokenPos >= 0)
                             break;
                     }
@@ -310,7 +310,7 @@ void ScanModFolder(ModInfo *info)
                     };
                     int tokenPos = -1;
                     for (int i = 0; i < 4; ++i) {
-                        tokenPos = FindStringToken(modBuf, folderTest[i], 1);
+                        tokenPos = FindLastStringToken(modBuf, folderTest[i]);
                         if (tokenPos >= 0)
                             break;
                     }

--- a/RSDKv4/String.cpp
+++ b/RSDKv4/String.cpp
@@ -225,6 +225,34 @@ int FindStringToken(const char *string, const char *token, char stopID)
     return -1;
 }
 
+int FindLastStringToken(const char *string, const char *token)
+{
+    int tokenCharID  = 0;
+    bool tokenMatch  = true;
+    int stringCharID = 0;
+    int foundTokenID = 0;
+    int lastResult = -1;
+
+    while (string[stringCharID]) {
+        tokenCharID = 0;
+        tokenMatch  = true;
+        while (token[tokenCharID]) {
+            if (!string[tokenCharID + stringCharID])
+                return lastResult;
+
+            if (string[tokenCharID + stringCharID] != token[tokenCharID])
+                tokenMatch = false;
+
+            ++tokenCharID;
+        }
+        if (tokenMatch)
+            lastResult = stringCharID;
+
+        ++stringCharID;
+    }
+    return lastResult;
+}
+
 int FindStringTokenUnicode(const ushort *string, const ushort *token, char stopID)
 {
     int tokenCharID  = 0;

--- a/RSDKv4/String.hpp
+++ b/RSDKv4/String.hpp
@@ -140,6 +140,7 @@ inline int StrLength(const char *string)
 #endif
 }
 int FindStringToken(const char *string, const char *token, char stopID);
+int FindLastStringToken(const char *string, const char *token);
 
 inline void StrCopyW(ushort *dest, const ushort *src)
 {


### PR DESCRIPTION
Mod support does not work if the game is running from a parent directory that ends in Data. When it finds something in Data under a mod folder, it appears to be trying to create that path relative to Data/ but it stops at the first instance of Data/.

When running debug builds out of the Xcode debugger, apps are compiled by default into a folder called DerivedData/ so this makes debugging with mods installed not really feasible. Fix the problem by finding the last instance of the Data/ token instead of the first one.

I don't know if this fix will break anything else so please consider the implications.