### PR TITLE
Fix link to Mac release

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ If you want to transfer your save(s) from the official mobile version(s), the **
 
 ## Mac
 * Clone the repo, follow the instructions in the [dependencies readme for Mac](./dependencies/mac/dependencies.txt) to setup dependencies, then build via the Xcode project.
-* Alternatively, a Mac build of v1.3.1 by [Sappharad](https://github.com/Sappharad) can be found [here](https://github.com/Sappharad/Sonic-1-2-2013-Decompilation/releases/tag/1.3.1-mac).
+* Alternatively, a Mac build of v1.3.1 by [Sappharad](https://github.com/Sappharad) can be found [here](https://github.com/Sappharad/Sonic-1-2-2013-Decompilation/releases/tag/v1.3.1-mac).
 
 ## Android
 * Clone the repo, then follow the instructions in the [dependencies readme for Android](./dependencies/android/dependencies.txt).


### PR DESCRIPTION
The tag in the url was missing the `v`, which was causing GitHub to 404.