### PR TITLE
Bing back the disable focus pause on android

### DIFF
--- a/RSDKv4/RetroEngine.cpp
+++ b/RSDKv4/RetroEngine.cpp
@@ -310,7 +310,9 @@ void RetroEngine::Init()
 #elif RETRO_PLATFORM == RETRO_ANDROID
     StrCopy(dest, gamePath);
     StrAdd(dest, Engine.dataFile[0]);
+#if !RETRO_USE_MOD_LOADER
     disableFocusPause = 0; // focus pause is ALWAYS enabled.
+#endif
 #else
 
     StrCopy(dest, BASE_PATH);


### PR DESCRIPTION
The disable focus pause is completely disabled on Android for some reason, so since this is something very useful for several mods, it is a better idea to have it there but only if the mod loader is activated.