### PR TITLE
Added support for the v6 HW Menu

### DIFF
--- a/RSDKv4/Debug.cpp
+++ b/RSDKv4/Debug.cpp
@@ -269,7 +269,13 @@ void ProcessStageSelect()
                     }
                     else {
 #endif
+
+#if !RETRO_USE_V6
                         CREATE_ENTITY(SegaSplash);
+#else
+                        CREATE_ENTITY(CWSplash);
+#endif
+
 #if !RETRO_USE_ORIGINAL_CODE
                     }
 #endif

--- a/RSDKv4/NativeObjects/CWSplash.cpp
+++ b/RSDKv4/NativeObjects/CWSplash.cpp
@@ -1,5 +1,96 @@
 #include "RetroEngine.hpp"
 
+#if RETRO_USE_V6
+void loadTextureAll()
+{
+    // Load all textures, because it skips the Title Screen (and in the decomp, skips SegaSplash, which also loads the texture like the Title Screen)
+     ResetBitmapFonts();
+    int heading = 0, labelTex = 0, textTex = 0;
+
+    if (Engine.useHighResAssets)
+        heading = LoadTexture("Data/Game/Menu/Heading_EN.png", TEXFMT_RGBA4444);
+    else
+        heading = LoadTexture("Data/Game/Menu/Heading_EN@1x.png", TEXFMT_RGBA4444);
+
+    LoadBitmapFont("Data/Game/Menu/Heading_EN.fnt", FONT_HEADING, heading);
+
+    if (Engine.useHighResAssets)
+        labelTex = LoadTexture("Data/Game/Menu/Label_EN.png", TEXFMT_RGBA4444);
+    else
+        labelTex = LoadTexture("Data/Game/Menu/Label_EN@1x.png", TEXFMT_RGBA4444);
+    LoadBitmapFont("Data/Game/Menu/Label_EN.fnt", FONT_LABEL, labelTex);
+
+    textTex = LoadTexture("Data/Game/Menu/Text_EN.png", TEXFMT_RGBA4444);
+    LoadBitmapFont("Data/Game/Menu/Text_EN.fnt", FONT_TEXT, textTex);
+
+    switch (Engine.language) {
+        case RETRO_JP:
+            heading = LoadTexture("Data/Game/Menu/Heading_JA@1x.png", TEXFMT_RGBA4444);
+            LoadBitmapFont("Data/Game/Menu/Heading_JA.fnt", FONT_HEADING, heading);
+
+            labelTex = LoadTexture("Data/Game/Menu/Label_JA@1x.png", TEXFMT_RGBA4444);
+            LoadBitmapFont("Data/Game/Menu/Label_JA.fnt", FONT_LABEL, labelTex);
+
+            textTex = LoadTexture("Data/Game/Menu/Text_JA@1x.png", TEXFMT_RGBA4444);
+            LoadBitmapFont("Data/Game/Menu/Text_JA.fnt", FONT_TEXT, textTex);
+            break;
+        case RETRO_RU:
+            if (Engine.useHighResAssets)
+                heading = LoadTexture("Data/Game/Menu/Heading_RU.png", TEXFMT_RGBA4444);
+            else
+                heading = LoadTexture("Data/Game/Menu/Heading_RU@1x.png", TEXFMT_RGBA4444);
+            LoadBitmapFont("Data/Game/Menu/Heading_RU.fnt", FONT_HEADING, heading);
+
+            if (Engine.useHighResAssets)
+                labelTex = LoadTexture("Data/Game/Menu/Label_RU.png", TEXFMT_RGBA4444);
+            else
+                labelTex = LoadTexture("Data/Game/Menu/Label_RU@1x.png", TEXFMT_RGBA4444);
+            LoadBitmapFont("Data/Game/Menu/Label_RU.fnt", FONT_LABEL, labelTex);
+            break;
+        case RETRO_KO:
+            heading = LoadTexture("Data/Game/Menu/Heading_KO@1x.png", TEXFMT_RGBA4444);
+            LoadBitmapFont("Data/Game/Menu/Heading_KO.fnt", FONT_HEADING, heading);
+
+            labelTex = LoadTexture("Data/Game/Menu/Label_KO@1x.png", TEXFMT_RGBA4444);
+            LoadBitmapFont("Data/Game/Menu/Label_KO.fnt", FONT_LABEL, labelTex);
+
+            textTex = LoadTexture("Data/Game/Menu/Text_KO.png", TEXFMT_RGBA4444);
+            LoadBitmapFont("Data/Game/Menu/Text_KO.fnt", FONT_TEXT, textTex);
+            break;
+        case RETRO_ZH:
+            heading = LoadTexture("Data/Game/Menu/Heading_ZH@1x.png", TEXFMT_RGBA4444);
+            LoadBitmapFont("Data/Game/Menu/Heading_ZH.fnt", FONT_HEADING, heading);
+
+            labelTex = LoadTexture("Data/Game/Menu/Label_ZH@1x.png", TEXFMT_RGBA4444);
+            LoadBitmapFont("Data/Game/Menu/Label_ZH.fnt", FONT_LABEL, labelTex);
+
+            textTex = LoadTexture("Data/Game/Menu/Text_ZH@1x.png", TEXFMT_RGBA4444);
+            LoadBitmapFont("Data/Game/Menu/Text_ZH.fnt", FONT_TEXT, textTex);
+            break;
+        case RETRO_ZS:
+            heading = LoadTexture("Data/Game/Menu/Heading_ZHS@1x.png", TEXFMT_RGBA4444);
+            LoadBitmapFont("Data/Game/Menu/Heading_ZHS.fnt", FONT_HEADING, heading);
+            labelTex = LoadTexture("Data/Game/Menu/Label_ZHS@1x.png", TEXFMT_RGBA4444);
+            LoadBitmapFont("Data/Game/Menu/Label_ZHS.fnt", FONT_LABEL, labelTex);
+            textTex = LoadTexture("Data/Game/Menu/Text_ZHS@1x.png", TEXFMT_RGBA4444);
+            LoadBitmapFont("Data/Game/Menu/Text_ZHS.fnt", FONT_TEXT, textTex);
+            break;
+        default: break;
+    }
+    SetMusicTrack("MenuIntro.ogg", 0, false, 0);
+    SetMusicTrack("MainMenu.ogg", 1, true, 106596);
+        LoadTexture("Data/Game/Menu/Circle.png", TEXFMT_RGBA4444);
+    LoadTexture("Data/Game/Menu/BG1.png", TEXFMT_RGBA4444);
+    LoadTexture("Data/Game/Menu/ArrowButtons.png", TEXFMT_RGBA4444);
+    if (Engine.gameDeviceType == RETRO_MOBILE)
+        LoadTexture("Data/Game/Menu/VirtualDPad.png", TEXFMT_RGBA8888);
+    else
+        LoadTexture("Data/Game/Menu/Amazon.png", TEXFMT_RGBA8888);
+    LoadTexture("Data/Game/Menu/PlayerSelect.png", TEXFMT_RGBA8888);
+    LoadTexture("Data/Game/Menu/SegaID.png", TEXFMT_RGBA8888);
+}
+#endif
+
 void CWSplash_Create(void *objPtr)
 {
     RSDK_THIS(CWSplash);
@@ -32,6 +123,18 @@ void CWSplash_Main(void *objPtr)
             RenderImage(0.0, 0.0, 160.0, 0.25, 0.25, 512.0, 256.0, 1024.0, 512.0, 0.0, 0.0, 255, self->textureID);
             RenderRect(-SCREEN_CENTERX_F, SCREEN_CENTERY_F, 160.0, SCREEN_XSIZE_F, SCREEN_YSIZE_F, 0, 0, 0, self->rectAlpha);
             break;
+#if RETRO_USE_V6
+        case CWSPLASH_STATE_SPAWNTITLE: 
+        #if RETRO_USE_V6
+            //actually used in v6
+            loadTextureAll();
+            ResetNativeObject(self, MenuControl_Create, MenuControl_Main); 
+        #else
+            ResetNativeObject(self, TitleScreen_Create, TitleScreen_Main);
+        #endif
+        break;
+#else
         case CWSPLASH_STATE_SPAWNTITLE: ResetNativeObject(self, TitleScreen_Create, TitleScreen_Main); break;
+#endif
     }
 }

--- a/RSDKv4/NativeObjects/CWSplash.hpp
+++ b/RSDKv4/NativeObjects/CWSplash.hpp
@@ -12,4 +12,9 @@ struct NativeEntity_CWSplash : NativeEntityBase {
 void CWSplash_Create(void *objPtr);
 void CWSplash_Main(void *objPtr);
 
+#if RETRO_USE_V6
+// actual function in v6 btw, very needed with the way it skips title screen
+void loadTextureAll();
+#endif
+
 #endif // !NATIVE_CWSPLASH_H

--- a/RSDKv4/NativeObjects/PlayerSelectScreen.cpp
+++ b/RSDKv4/NativeObjects/PlayerSelectScreen.cpp
@@ -26,8 +26,9 @@ void PlayerSelectScreen_Create(void *objPtr)
 
     self->meshPanel = LoadMesh("Data/Game/Models/Panel.bin", 255);
     SetMeshVertexColors(self->meshPanel, 0, 0, 0, 0xC0);
-
+#if !RETRO_USE_V6
     self->textureArrows    = LoadTexture("Data/Game/Menu/ArrowButtons.png", TEXFMT_RGBA4444);
+#endif
     self->texturePlayerSel = LoadTexture("Data/Game/Menu/PlayerSelect.png", TEXFMT_RGBA8888);
     self->backPressed      = false;
     self->flag             = true;
@@ -80,11 +81,14 @@ void PlayerSelectScreen_Main(void *objPtr)
                     if (keyPress.left) {
                         if (saveGame->knuxUnlocked) {
                             PlaySfxByName("Menu Move", false);
+                            PlaySfxByName("MenuButton", false);
+
                             if (--self->playerID < SAVESEL_SONIC)
                                 self->playerID = SAVESEL_KNUX;
                         }
                         else if (saveGame->tailsUnlocked) {
                             PlaySfxByName("Menu Move", false);
+                            PlaySfxByName("MenuButton", false);
                             if (--self->playerID > SAVESEL_SONIC)
                                 self->playerID = SAVESEL_TAILS;
                         }
@@ -92,12 +96,14 @@ void PlayerSelectScreen_Main(void *objPtr)
                     else if (keyPress.right) {
                         if (saveGame->knuxUnlocked) {
                             PlaySfxByName("Menu Move", false);
+                            PlaySfxByName("MenuButton", false);
 
                             if (++self->playerID > SAVESEL_KNUX)
                                 self->playerID = SAVESEL_SONIC;
                         }
                         else if (saveGame->tailsUnlocked) {
                             PlaySfxByName("Menu Move", false);
+                            PlaySfxByName("MenuButton", false);
 
                             if (++self->playerID > SAVESEL_TAILS)
                                 self->playerID = SAVESEL_SONIC;
@@ -108,6 +114,7 @@ void PlayerSelectScreen_Main(void *objPtr)
                     }
                     if (keyPress.start || keyPress.A) {
                         PlaySfxByName("Menu Select", false);
+                        PlaySfxByName("Select", false);
                         StopMusic(true);
                         self->state = PLAYERSELECTSCREEN_STATE_ACTION;
                     }
@@ -161,6 +168,7 @@ void PlayerSelectScreen_Main(void *objPtr)
                 else {
                     if (self->playerID > 0) {
                         PlaySfxByName("Menu Select", false);
+                        PlaySfxByName("Select", false);
                         StopMusic(true);
                         self->state = PLAYERSELECTSCREEN_STATE_ACTION;
                     }
@@ -224,6 +232,9 @@ void PlayerSelectScreen_Main(void *objPtr)
                 SetGlobalVariableByName("timeAttack.result", 0);
                 SetGlobalVariableByName("lampPostID", 0);
                 SetGlobalVariableByName("starPostID", 0);
+#if RETRO_USE_V6
+                SetGlobalVariableByName("specialStage.timeStones", 0);
+#endif
                 debugMode = false;
 
                 int charID = 0;
@@ -379,8 +390,14 @@ void PlayerSelectScreen_Main(void *objPtr)
     NewRenderState();
     SetRenderMatrix(NULL);
     SetRenderVertexColor(0xFF, 0xFF, 0xFF);
-    if (self->backPressed)
+    if (self->backPressed){
+        #if !RETRO_USE_V6
         RenderImage(128.0, -92.0, 160.0, 0.3, 0.3, 64.0, 64.0, 128.0, 128.0, 128.0, 128.0, self->alpha, self->textureArrows);
-    else
+        #endif
+    }
+    else{
+        #if !RETRO_USE_V6
         RenderImage(128.0, -92.0, 160.0, 0.3, 0.3, 64.0, 64.0, 128.0, 128.0, 128.0, 0.0, self->alpha, self->textureArrows);
+        #endif
+    }
 }

--- a/RSDKv4/NativeObjects/RecordsScreen.cpp
+++ b/RSDKv4/NativeObjects/RecordsScreen.cpp
@@ -20,6 +20,7 @@ void RecordsScreen_Create(void *objPtr)
     SetMeshVertexColors(self->meshPanel, 0, 0, 0, 0xC0);
 
     self->textureArrows = LoadTexture("Data/Game/Menu/ArrowButtons.png", TEXFMT_RGBA5551);
+
     SetStringToFont(self->textRecords, strRecords, FONT_LABEL);
 
     self->recordTextWidth = GetTextWidth(self->textRecords, FONT_LABEL, 0.125) * 0.5;
@@ -743,8 +744,14 @@ void RecordsScreen_Main(void *objPtr)
             RenderImage(146.0, 0.0, 160.0, 0.2, 0.3, 64.0, 64.0, 128.0, 128.0, 0.0, 0.0, self->buttonAlpha, self->textureArrows);
     }
 
-    if (self->backPressed)
+    if (self->backPressed){
+    #if !RETRO_USE_V6
         RenderImage(128.0, -92.0, 160.0, 0.3, 0.3, 64.0, 64.0, 128.0, 128.0, 128.0, 128.0, self->buttonAlpha, self->textureArrows);
-    else
+    #endif
+    }
+    else{
+    #if !RETRO_USE_V6
         RenderImage(128.0, -92.0, 160.0, 0.3, 0.3, 64.0, 64.0, 128.0, 128.0, 128.0, 0.0, self->buttonAlpha, self->textureArrows);
+    #endif
+    }
 }

--- a/RSDKv4/NativeObjects/RetroGameLoop.hpp
+++ b/RSDKv4/NativeObjects/RetroGameLoop.hpp
@@ -8,4 +8,12 @@ struct NativeEntity_RetroGameLoop : NativeEntityBase {
 void RetroGameLoop_Create(void *objPtr);
 void RetroGameLoop_Main(void *objPtr);
 
+#if RETRO_USE_V6
+extern int tempGlobalVar; //i couldn't think of a better name, and it changes between global variables too
+extern const char *checkpointName; // this is fine ig
+
+void eventPauseMenuVisible(bool paused, int state); // not sure about the name "state", best i could come up with based on the output
+void showPauseScreenJava(); //as much as im gonna get without decompiling the classes files in the apk
+#endif
+
 #endif // !NATIVE_RETROGAMELOOP_H

--- a/RSDKv4/NativeObjects/SaveSelect.cpp
+++ b/RSDKv4/NativeObjects/SaveSelect.cpp
@@ -137,6 +137,7 @@ void SaveSelect_Main(void *objPtr)
                 else {
                     if (keyPress.up) {
                         PlaySfxByName("Menu Move", false);
+                        PlaySfxByName("MenuButton", false);
                         self->selectedButton--;
                         if (self->deleteEnabled && self->selectedButton < SAVESELECT_BUTTON_NOSAVE) {
                             self->selectedButton = SAVESELECT_BUTTON_COUNT;
@@ -147,6 +148,7 @@ void SaveSelect_Main(void *objPtr)
                     }
                     else if (keyPress.down) {
                         PlaySfxByName("Menu Move", false);
+                        PlaySfxByName("MenuButton", false);
                         self->selectedButton++;
                         if (self->deleteEnabled && self->selectedButton > SAVESELECT_BUTTON_COUNT) {
                             self->selectedButton = SAVESELECT_BUTTON_NOSAVE;
@@ -184,6 +186,7 @@ void SaveSelect_Main(void *objPtr)
                             if (self->state == SAVESELECT_STATE_MAIN_DELETING) {
                                 if (self->selectedButton > SAVESELECT_BUTTON_NOSAVE && saveGame->files[self->selectedButton - 1].stageID > 0) {
                                     PlaySfxByName("Menu Select", false);
+                                    PlaySfxByName("Select", false);
                                     self->state                                    = SAVESELECT_STATE_DELSETUP;
                                     self->saveButtons[self->selectedButton]->b     = 0xFF;
                                     self->saveButtons[self->selectedButton]->state = SUBMENUBUTTON_STATE_SAVEBUTTON_UNSELECTED;
@@ -191,6 +194,7 @@ void SaveSelect_Main(void *objPtr)
                             }
                             else {
                                 PlaySfxByName("Menu Select", false);
+                                PlaySfxByName("Select", false);
                                 self->saveButtons[self->selectedButton]->state = SUBMENUBUTTON_STATE_FLASHING2;
                                 if (self->selectedButton > SAVESELECT_BUTTON_NOSAVE && saveGame->files[self->selectedButton - 1].stageID > 0) {
                                     StopMusic(true);
@@ -235,6 +239,7 @@ void SaveSelect_Main(void *objPtr)
                         if (self->state == SAVESELECT_STATE_MAIN_DELETING) {
                             if (self->selectedButton > SAVESELECT_BUTTON_NOSAVE && saveGame->files[self->selectedButton - 1].stageID > 0) {
                                 PlaySfxByName("Menu Select", false);
+                                PlaySfxByName("Select", false);
                                 self->state                                    = SAVESELECT_STATE_DELSETUP;
                                 self->saveButtons[self->selectedButton]->b     = 0xFF;
                                 self->saveButtons[self->selectedButton]->state = SUBMENUBUTTON_STATE_SAVEBUTTON_UNSELECTED;
@@ -242,6 +247,7 @@ void SaveSelect_Main(void *objPtr)
                         }
                         else {
                             PlaySfxByName("Menu Select", false);
+                            PlaySfxByName("Select", false);
                             self->saveButtons[self->selectedButton]->state = SUBMENUBUTTON_STATE_FLASHING2;
                             if (self->selectedButton > SAVESELECT_BUTTON_NOSAVE && saveGame->files[self->selectedButton - 1].stageID > 0) {
                                 StopMusic(true);

--- a/RSDKv4/NativeObjects/SegaSplash.cpp
+++ b/RSDKv4/NativeObjects/SegaSplash.cpp
@@ -3,7 +3,11 @@
 void SegaSplash_Create(void *objPtr)
 {
     RSDK_THIS(SegaSplash);
+ //   #if RETRO_USE_V6
+ //   self->state     = SEGAPLASH_STATE_SPAWNCWSPLASH;
+//    #else
     self->state     = SEGAPLASH_STATE_ENTER;
+ //   #endif
     self->rectAlpha = 320.0;
     self->textureID = LoadTexture("Data/Game/Menu/CWLogo.png", TEXFMT_RGBA8888);
     if (Engine.useHighResAssets) {

--- a/RSDKv4/NativeObjects/StartGameButton.cpp
+++ b/RSDKv4/NativeObjects/StartGameButton.cpp
@@ -1,10 +1,60 @@
 #include "RetroEngine.hpp"
 
+#if RETRO_USE_V6
+void loadCartridgeValue(void *objPtr)
+{
+    RSDK_THIS(StartGameButton);
+    int package = 0;
+    if (Engine.gameType == GAME_SONICCD) {
+        switch (Engine.globalBoxRegion) {
+            case REGION_JP:
+                package        = LoadTexture("Data/Game/Models/DiscJP.png", TEXFMT_RGBA5551);
+                self->meshCart = LoadMesh("Data/Game/Models/MegaCDMedia.bin", package);
+                break;
+
+            case REGION_US:
+            //DiscJP_Transparent goes unused as you can't change the region in v6
+            //according to the original code, it loads the transparent disc texture for US and EU regions
+            //so imma just follow that logic here
+                package        = LoadTexture("Data/Game/Models/DiscJP_Transparent.png", TEXFMT_RGBA5551);
+                self->meshCart = LoadMesh("Data/Game/Models/MegaCDMedia.bin", package);
+                break;
+
+            case REGION_EU:
+                package        = LoadTexture("Data/Game/Models/DiscJP_Transparent.png", TEXFMT_RGBA5551);
+                self->meshCart = LoadMesh("Data/Game/Models/MegaCDMedia.bin", package);
+                break;
+        }
+        self->prevRegion = Engine.globalBoxRegion;
+    }
+    else{ //Sonic 1 and Sonic 2
+        switch (Engine.globalBoxRegion) {
+            case REGION_JP:
+                package        = LoadTexture("Data/Game/Models/Package_JP.png", TEXFMT_RGBA5551);
+                self->meshCart = LoadMesh("Data/Game/Models/JPCartridge.bin", package);
+                break;
+
+            case REGION_US:
+                package        = LoadTexture("Data/Game/Models/Package_US.png", TEXFMT_RGBA5551);
+                self->meshCart = LoadMesh("Data/Game/Models/Cartridge.bin", package);
+                break;
+
+            case REGION_EU:
+                package        = LoadTexture("Data/Game/Models/Package_EU.png", TEXFMT_RGBA5551);
+                self->meshCart = LoadMesh("Data/Game/Models/Cartridge.bin", package);
+                break;
+        }
+        self->prevRegion = Engine.globalBoxRegion;
+    }
+}
+#endif
 void StartGameButton_Create(void *objPtr)
 {
     RSDK_THIS(StartGameButton);
     self->textureCircle = LoadTexture("Data/Game/Menu/Circle.png", TEXFMT_RGBA4444);
-
+#if RETRO_USE_V6
+    loadCartridgeValue(objPtr);
+#else
     int package = 0;
     switch (Engine.globalBoxRegion) {
         case REGION_JP:
@@ -22,7 +72,7 @@ void StartGameButton_Create(void *objPtr)
             self->meshCart = LoadMesh("Data/Game/Models/Cartridge.bin", package);
             break;
     }
-
+#endif
     self->prevRegion       = Engine.globalBoxRegion;
     self->x                = 0.0;
     self->y                = 16.0;

--- a/RSDKv4/NativeObjects/StartGameButton.hpp
+++ b/RSDKv4/NativeObjects/StartGameButton.hpp
@@ -21,7 +21,11 @@ struct NativeEntity_StartGameButton : NativeEntityBase {
     NativeEntity_TextLabel *labelPtr;
     byte prevRegion;
 };
-
+#if RETRO_USE_V6
+void loadCartridgeValue(void *objPtr);
+//took 2 parameters, but one is used as a handle for the mesh
+//while the other is the region value, so we can just use the region directly
+#endif
 void StartGameButton_Create(void *objPtr);
 void StartGameButton_Main(void *objPtr);
 

--- a/RSDKv4/Object.cpp
+++ b/RSDKv4/Object.cpp
@@ -435,7 +435,11 @@ void InitNativeObjectSystem()
     }
     else
 #endif
+#if !RETRO_USE_V6
         CREATE_ENTITY(SegaSplash);
+#else
+        CREATE_ENTITY(CWSplash);
+#endif
 }
 NativeEntity *CreateNativeObject(void (*create)(void *objPtr), void (*main)(void *objPtr))
 {

--- a/RSDKv4/RetroEngine.cpp
+++ b/RSDKv4/RetroEngine.cpp
@@ -419,6 +419,12 @@ void RetroEngine::Init()
 
 #if !RETRO_USE_ORIGINAL_CODE
     gameType = GAME_SONIC2;
+
+#if RETRO_USE_V6
+    if (strstr(gameWindowText, "Sonic CD")) {
+        gameType = GAME_SONICCD;
+    } else
+#endif
 #if RETRO_USE_MOD_LOADER
     if (strstr(gameWindowText, "Sonic 1") || forceSonic1) {
 #else
@@ -427,6 +433,7 @@ void RetroEngine::Init()
         gameType = GAME_SONIC1;
     }
 #endif
+
 
 #if !RETRO_USE_ORIGINAL_CODE
     bool skipStore = skipStartMenu;
@@ -1259,7 +1266,7 @@ bool RetroEngine::LoadGameConfig(const char *filePath)
     nativeFunctionCount = 0;
     AddNativeFunction("SetAchievement", SetAchievement);
     AddNativeFunction("SetLeaderboard", SetLeaderboard);
-#if RETRO_USE_HAPTICS
+#if RETRO_USE_HAPTICS || !RETRO_USE_V6
     AddNativeFunction("HapticEffect", HapticEffect);
 #endif
     AddNativeFunction("Connect2PVS", Connect2PVS);
@@ -1270,6 +1277,10 @@ bool RetroEngine::LoadGameConfig(const char *filePath)
     AddNativeFunction("ReceiveValue", ReceiveValue);
     AddNativeFunction("TransmitGlobal", TransmitGlobal);
     AddNativeFunction("ShowPromoPopup", ShowPromoPopup);
+
+#if RETRO_USE_V6
+    AddNativeFunction("PlayVideo", PlayVideo);
+#endif
 
     // Introduced in the Sega Forever versions of S1 (3.9.0) and S2 (1.7.0)
     AddNativeFunction("NativePlayerWaitingAds", NativePlayerWaitingAds);

--- a/RSDKv4/RetroEngine.hpp
+++ b/RSDKv4/RetroEngine.hpp
@@ -237,6 +237,11 @@ typedef unsigned int uint;
 // Revision included as part of RSDKv5U (Sonic Origins)
 #define RETRO_REV03 (RSDK_REVISION >= 3)
 
+// Whether or not the HW Menus will use the version used in SEGA Classics (2018) application for Amazon Fire TV
+#ifndef RETRO_USE_V6
+#define RETRO_USE_V6 (0)
+#endif
+
 enum RetroLanguages {
     RETRO_EN = 0,
     RETRO_FR = 1,
@@ -272,6 +277,10 @@ enum RetroStates {
     ENGINE_ENDGAME     = 7,
     ENGINE_RESETGAME   = 8,
 
+#if RETRO_USE_V6
+    // New engine state in RSDKv6
+    ENGINE_INITJAVAPAUSE = 9, // The pause menu for SEGA Classics uses a Java interface.
+#endif
 #if !RETRO_USE_ORIGINAL_CODE && RETRO_USE_NETWORKING
     // Custom GameModes (required to make some features work)
     ENGINE_CONNECT2PVS = 0x80,
@@ -283,11 +292,23 @@ enum RetroStates {
 };
 
 enum RetroGameType {
+#if !RETRO_USE_V6
     GAME_UNKNOWN = 0,
     GAME_SONIC1  = 1,
     GAME_SONIC2  = 2,
+#else
+    // GetSonic() and sonicType enum in SonicBaseActivity.java
+    GAME_SONIC1  = 0, 
+    GAME_SONIC2  = 1, 
+    GAME_SONICCD = 2, 
+    GAME_UNKNOWN = 3, // kept for compatibility with the decompilation
+#endif
 };
 
+#if RETRO_USE_V6
+// in SonicBaseActivity.java, inside InitActivity(), RetroEngine.setDeviceType(0) is called
+#define RETRO_GAMEPLATFORM (RETRO_STANDARD)
+#endif
 // General Defines
 #define SCREEN_YSIZE   (240)
 #define SCREEN_CENTERY (SCREEN_YSIZE / 2)
@@ -420,6 +441,7 @@ public:
 
     bool showPaletteOverlay = false;
     bool useHQModes         = true;
+
 
     bool hasFocus  = true;
     int focusState = 0;

--- a/RSDKv4/Scene.cpp
+++ b/RSDKv4/Scene.cpp
@@ -123,6 +123,27 @@ void InitStartingStage(int list, int stage, int player)
     stageListPosition = stage;
 }
 
+void InitStartingStageMode(int list, int stage)
+{
+    //top 5 most useless functions
+    xScrollOffset = 0;
+    yScrollOffset = 0;
+    StopMusic(true);
+    StopAllSfx();
+    ReleaseStageSfx();
+    fadeMode      = 0;
+    ClearGraphicsData();
+    ClearAnimationData();
+    ResetCurrentStageFolder();
+    activeStageList   = list;
+    activePalette     = fullPalette[0];
+    activePalette32   = fullPalette32[0];
+    stageMode         = STAGEMODE_LOAD;
+    Engine.gameMode   = ENGINE_MAINGAME;
+    stageListPosition = stage;
+
+}
+
 void ProcessStage(void)
 {
 #if !RETRO_USE_ORIGINAL_CODE

--- a/RSDKv4/Scene.hpp
+++ b/RSDKv4/Scene.hpp
@@ -213,6 +213,9 @@ extern bool drawStageGFXHQ;
 
 void InitFirstStage();
 void InitStartingStage(int list, int stage, int player);
+#if RETRO_USE_V6
+void InitStartingStageMode(int list, int stage); //It's the same fuckass thing, just without the player param
+#endif
 void ProcessStage();
 
 void ProcessParallaxAutoScroll();

--- a/RSDKv4/Userdata.cpp
+++ b/RSDKv4/Userdata.cpp
@@ -1173,6 +1173,14 @@ void ShowWebsite(int websiteID)
     }
 }
 
+#if RETRO_USE_V6
+void PlayVideo(int unused, const char *videoName)
+{
+    PrintLog("Loaded Video: \"%s\"", videoName);
+    // The day S3KO gets decompiled I'll make an mp4 video player
+}
+#endif
+
 #if RETRO_REV03
 enum NotifyCallbackIDs {
     NOTIFY_DEATH_EVENT         = 128,

--- a/RSDKv4/Userdata.hpp
+++ b/RSDKv4/Userdata.hpp
@@ -214,6 +214,12 @@ void ShowWebsite(int websiteID);
 inline void NativePlayerWaitingAds() { SetGlobalVariableByName("waitingAds.result", 2); }
 inline void NativeWaterPlayerWaitingAds() { SetGlobalVariableByName("waitingAds.water", 2); }
 
+#if RETRO_USE_V6
+// Native Function used in RSDKv6 for Sonic CD
+// It's just handled by the phone's native video player anyway, so we don't need to do anything here
+void PlayVideo(int unused, const char *videoName);
+#endif
+
 #if RETRO_REV03
 void NotifyCallback(int *callback, int *param1, int *param2, int *param3);
 #endif


### PR DESCRIPTION
Reimplemented tons of stuff from the SEGA Classics / RSDKv6 HW Menu as a RetroEngine.hpp define. These include: -2 button layout
-Support for Sonic CD (2018)

-- New Functions --
-PlayVideo (native function)
-loadTextureAll
-loadCartridgeValue
-eventPauseMenuVisible
-showPauseScreenJava
-InitStartingStageMode

-- Misc. --
-gameType enum that emulates the GetSonic() function and sonicType variable -new gameMode state

-- Missing/Issues --
-Player Select Screen that only displays 2 characters when playing CD -Pausing the game will throw you into a softlock, as there is no (usable) code for gameMode state 9

-- Conclusion --
The first time I do something this size and I feel proud of how it turned out. Thank you to anyone for reading this until the very end.